### PR TITLE
#42 공연장 좌석 배치도 API

### DIFF
--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/stadium/StadiumController.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/stadium/StadiumController.java
@@ -1,0 +1,32 @@
+package wisoft.nextframe.schedulereservationticketing.controller.stadium;
+
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import wisoft.nextframe.schedulereservationticketing.common.response.ApiResponse;
+import wisoft.nextframe.schedulereservationticketing.dto.seatdefinition.SeatDefinitionListResponse;
+import wisoft.nextframe.schedulereservationticketing.service.stadium.StadiumService;
+
+@RestController
+@RequestMapping("/api/v1/stadiums")
+@RequiredArgsConstructor
+public class StadiumController {
+
+	private final StadiumService stadiumService;
+
+	@GetMapping("/{id}/seat-definitions")
+	public ResponseEntity<ApiResponse<?>> getSeatDefinitions(@PathVariable UUID id) {
+		final SeatDefinitionListResponse data = stadiumService.getSeatDefinitions(id);
+
+		final ApiResponse<SeatDefinitionListResponse> response = ApiResponse.success(data);
+
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/dto/performancedetail/response/PerformanceDetailResponse.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/dto/performancedetail/response/PerformanceDetailResponse.java
@@ -1,5 +1,6 @@
 package wisoft.nextframe.schedulereservationticketing.dto.performancedetail.response;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -19,6 +20,8 @@ public class PerformanceDetailResponse {
 	private final Integer runningTime;
 	private final String description;
 	private final Boolean adultOnly;
+	private final LocalDateTime ticketOpenTime;
+	private final LocalDateTime ticketCloseTime;
 	private final StadiumResponse stadium;
 	private final List<PerformanceScheduleResponse> performanceSchedules;
 	private final List<SeatSectionPriceResponse> seatSectionPrices;

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/dto/seatdefinition/SeatDefinitionListResponse.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/dto/seatdefinition/SeatDefinitionListResponse.java
@@ -1,10 +1,12 @@
 package wisoft.nextframe.schedulereservationticketing.dto.seatdefinition;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import wisoft.nextframe.schedulereservationticketing.entity.stadium.SeatDefinition;
 
 @Getter
 @Builder
@@ -12,4 +14,19 @@ import lombok.Getter;
 public class SeatDefinitionListResponse {
 
 	private final List<SeatDefinitionResponse> seats;
+
+	/**
+	 * SeatDefinition 엔티티 리스트를 DTO로 변환하는 정적 팩토리 메서드
+	 * @param seatDefinitions 변환할 엔티티 리스트
+	 * @return 변환된 DTO 객체
+	 */
+	public static SeatDefinitionListResponse from(List<SeatDefinition> seatDefinitions) {
+		List<SeatDefinitionResponse> seatDtoList = seatDefinitions.stream()
+			.map(SeatDefinitionResponse::from) // 위에서 만든 DTO의 변환 메서드 사용
+			.collect(Collectors.toList());
+
+		return SeatDefinitionListResponse.builder()
+			.seats(seatDtoList)
+			.build();
+	}
 }

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/dto/seatdefinition/SeatDefinitionListResponse.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/dto/seatdefinition/SeatDefinitionListResponse.java
@@ -1,0 +1,15 @@
+package wisoft.nextframe.schedulereservationticketing.dto.seatdefinition;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SeatDefinitionListResponse {
+
+	private final List<SeatDefinitionResponse> seats;
+}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/dto/seatdefinition/SeatDefinitionResponse.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/dto/seatdefinition/SeatDefinitionResponse.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import wisoft.nextframe.schedulereservationticketing.entity.stadium.SeatDefinition;
 
 @Getter
 @Builder
@@ -15,4 +16,18 @@ public class SeatDefinitionResponse {
 	private final String section;
 	private final Integer row;
 	private final Integer column;
+
+	/**
+	 * SeatDefinition 엔티티를 DTO로 변환하는 정적 팩토리 메서드
+	 * @param seatDefinition 변환할 엔티티 객체
+	 * @return 변환된 DTO 객체
+	 */
+	public static SeatDefinitionResponse from(SeatDefinition seatDefinition) {
+		return SeatDefinitionResponse.builder()
+			.id(seatDefinition.getId())
+			.section(seatDefinition.getStadiumSection().getSection())
+			.row(seatDefinition.getRowNo())
+			.column(seatDefinition.getColumnNo())
+			.build();
+	}
 }

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/dto/seatdefinition/SeatDefinitionResponse.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/dto/seatdefinition/SeatDefinitionResponse.java
@@ -1,0 +1,18 @@
+package wisoft.nextframe.schedulereservationticketing.dto.seatdefinition;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SeatDefinitionResponse {
+
+	private final UUID id;
+	private final String section;
+	private final Integer row;
+	private final Integer column;
+}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/performance/PerformancePricing.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/performance/PerformancePricing.java
@@ -13,6 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import wisoft.nextframe.schedulereservationticketing.entity.schedule.Schedule;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.StadiumSection;
 
 @Getter
@@ -26,10 +27,10 @@ public class PerformancePricing {
 	@EmbeddedId
 	private PerformancePricingId id;
 
-	@MapsId("performanceId")
+	@MapsId("scheduleId")
 	@ManyToOne(fetch = FetchType.LAZY, optional = false)
-	@JoinColumn(name = "performance_id", nullable = false)
-	private Performance performance;
+	@JoinColumn(name = "schedule_id", nullable = false)
+	private Schedule schedule;
 
 	@MapsId("stadiumSectionId")
 	@ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/performance/PerformancePricingId.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/performance/PerformancePricingId.java
@@ -20,8 +20,8 @@ import lombok.NoArgsConstructor;
 @EqualsAndHashCode
 public class PerformancePricingId implements Serializable {
 
-	@Column(name = "performance_id", nullable = false)
-	private UUID performanceId;
+	@Column(name = "schedule_id", nullable = false)
+	private UUID scheduleId;
 
 	@Column(name = "stadium_section_id", nullable = false)
 	private UUID stadiumSectionId;

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformancePricingRepository.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformancePricingRepository.java
@@ -10,6 +10,11 @@ import wisoft.nextframe.schedulereservationticketing.entity.performance.Performa
 
 public interface PerformancePricingRepository extends JpaRepository<PerformancePricing, PerformancePricingId> {
 
+	/*
+	todo: 데이터 모델 수정 필요
+	- 현재 이 메서드를 호출하면, 특정 공연장이나 일정(Schedule)에 관계없이 해당 공연(Performance)에 연결된 모든 가격 정보가 한꺼번에 조회된다.
+	  -> 이 문제를 해결하려면, 가격 정보가 Performance가 아닌 Schedule에 직접 연결되도록 데이터 모델을 변경해야 함.
+	 */
 	List<PerformancePricing> findByPerformanceId(UUID performanceId);
 
 	/**

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformancePricingRepository.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformancePricingRepository.java
@@ -4,24 +4,36 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import wisoft.nextframe.schedulereservationticketing.dto.performancedetail.response.SeatSectionPriceResponse;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.PerformancePricing;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.PerformancePricingId;
 
 public interface PerformancePricingRepository extends JpaRepository<PerformancePricing, PerformancePricingId> {
 
-	/*
-	todo: 데이터 모델 수정 필요
-	- 현재 이 메서드를 호출하면, 특정 공연장이나 일정(Schedule)에 관계없이 해당 공연(Performance)에 연결된 모든 가격 정보가 한꺼번에 조회된다.
-	  -> 이 문제를 해결하려면, 가격 정보가 Performance가 아닌 Schedule에 직접 연결되도록 데이터 모델을 변경해야 함.
-	 */
-	List<PerformancePricing> findByPerformanceId(UUID performanceId);
-
 	/**
-	 * 특정 공연과 여러 섹션 ID에 해당하는 가격 정보를 모두 조회합니다.
-	 * @param performanceId 공연 ID
-	 * @param sectionIds 스타디움 섹션 ID 목록
-	 * @return 가격 정보 목록
+	 * 특정 공연과 공연장의 조합에 대한 공통 좌석 가격 정보를 조회합니다.
+	 * DISTINCT를 사용하여 여러 스케줄에 동일한 가격이 있어도 중복을 제거합니다.
+	 *
+	 * @param performanceId 조회할 공연의 ID
+	 * @param stadiumId 조회할 공연장의 ID
+	 * @return 좌석 등급과 가격 정보가 담긴 DTO 리스트
 	 */
-	List<PerformancePricing> findById_PerformanceIdAndId_StadiumSectionIdIn(UUID performanceId, List<UUID> sectionIds);
+	@Query("""
+		    SELECT DISTINCT new wisoft.nextframe.schedulereservationticketing.dto.performancedetail.response.SeatSectionPriceResponse(
+		        ss.section,
+		        pp.price
+		    )
+		    FROM PerformancePricing pp
+		    JOIN pp.schedule s
+		    JOIN pp.stadiumSection ss
+		    WHERE s.performance.id = :performanceId AND s.stadium.id = :stadiumId
+		    ORDER BY pp.price DESC
+		""")
+	List<SeatSectionPriceResponse> findCommonPricingByPerformanceAndStadium(
+		@Param("performanceId") UUID performanceId,
+		@Param("stadiumId") UUID stadiumId
+	);
 }

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/stadium/SeatDefinitionRepository.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/stadium/SeatDefinitionRepository.java
@@ -11,6 +11,13 @@ import wisoft.nextframe.schedulereservationticketing.entity.stadium.SeatDefiniti
 
 public interface SeatDefinitionRepository extends JpaRepository<SeatDefinition, UUID> {
 
+	@Query(value = """
+				select sd from SeatDefinition sd
+				join fetch sd.stadiumSection ss
+				order by ss.section asc, sd.rowNo asc, sd.columnNo asc 
+		""")
+	List<SeatDefinition> findAllByStadiumIdWithSorting(@Param("stadiumId") UUID stadiumId);
+
 	/**
 	 * 여러 좌석 ID에 해당하는 좌석 정보를 모두 조회합니다. (N+1 문제 방지를 위해 fetch join 사용)
 	 * @param seatIds 좌석 ID 목록

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/stadium/SeatDefinitionRepository.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/stadium/SeatDefinitionRepository.java
@@ -11,11 +11,10 @@ import wisoft.nextframe.schedulereservationticketing.entity.stadium.SeatDefiniti
 
 public interface SeatDefinitionRepository extends JpaRepository<SeatDefinition, UUID> {
 
-	@Query(value = """
-				select sd from SeatDefinition sd
-				join fetch sd.stadiumSection ss
-				order by ss.section asc, sd.rowNo asc, sd.columnNo asc 
-		""")
+	@Query("SELECT sd FROM SeatDefinition sd " +
+		"JOIN FETCH sd.stadiumSection ss " +
+		"WHERE ss.stadium.id = :stadiumId " +
+		"ORDER BY ss.section ASC, sd.rowNo ASC, sd.columnNo ASC")
 	List<SeatDefinition> findAllByStadiumIdWithSorting(@Param("stadiumId") UUID stadiumId);
 
 	/**

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/stadium/SeatDefinitionRepository.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/stadium/SeatDefinitionRepository.java
@@ -24,4 +24,5 @@ public interface SeatDefinitionRepository extends JpaRepository<SeatDefinition, 
 	 */
 	@Query("select sd from SeatDefinition sd join fetch sd.stadiumSection where sd.id in :seatIds")
 	List<SeatDefinition> findWithStadiumSectionByIdIn(@Param("seatIds") List<UUID> seatIds);
+
 }

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/performance/PerformanceService.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/performance/PerformanceService.java
@@ -1,5 +1,6 @@
 package wisoft.nextframe.schedulereservationticketing.service.performance;
 
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.UUID;
@@ -93,6 +94,14 @@ public class PerformanceService {
 				.build())
 			.toList();
 
+		LocalDateTime ticketOpenTime = null;
+		LocalDateTime ticketCloseTime = null;
+
+		if (!schedules.isEmpty()) {
+			ticketOpenTime = schedules.getFirst().getTicketOpenTime();
+			ticketCloseTime = schedules.getFirst().getTicketCloseTime();
+		}
+
 		// 최종 응답 DTO 조립
 		return PerformanceDetailResponse.builder()
 			.id(performance.getId())
@@ -104,6 +113,8 @@ public class PerformanceService {
 			.runningTime((int)performance.getRunningTime().toMinutes())
 			.description(performance.getDescription())
 			.adultOnly(performance.getAdultOnly())
+			.ticketOpenTime(ticketOpenTime)
+			.ticketCloseTime(ticketCloseTime)
 			.stadium(stadiumResponse)
 			.performanceSchedules(scheduleDtos)
 			.seatSectionPrices(seatSectionPriceResponses)

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/stadium/StadiumService.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/stadium/StadiumService.java
@@ -1,0 +1,41 @@
+package wisoft.nextframe.schedulereservationticketing.service.stadium;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import wisoft.nextframe.schedulereservationticketing.dto.seatdefinition.SeatDefinitionListResponse;
+import wisoft.nextframe.schedulereservationticketing.entity.stadium.SeatDefinition;
+import wisoft.nextframe.schedulereservationticketing.repository.stadium.SeatDefinitionRepository;
+import wisoft.nextframe.schedulereservationticketing.repository.stadium.StadiumRepository;
+
+@Service
+@RequiredArgsConstructor
+public class StadiumService {
+
+	private final StadiumRepository stadiumRepository;
+	private final SeatDefinitionRepository seatDefinitionRepository;
+
+	/**
+	 * 특정 공연장의 모든 좌석 정보를 조회합니다.
+	 *
+	 * @param stadiumId 공연장 ID
+	 * @return 좌석 정보 DTO 리스트
+	 * @throws EntityNotFoundException 해당 ID의 공연장이 존재하지 않을 경우 발생
+	 */
+	@Transactional(readOnly = true)
+	public SeatDefinitionListResponse getSeatDefinitions(UUID stadiumId) {
+		// 1. 공연장 존재 여부 확인
+		stadiumRepository.findById(stadiumId).orElseThrow(EntityNotFoundException::new);
+
+		// 2. 공연장의 좌석 데이터 조회
+		final List<SeatDefinition> seatDefinitions = seatDefinitionRepository.findAllByStadiumIdWithSorting(stadiumId);
+
+		// 3. 조회된 엔티티 목록을 응답 DTO로 변환하여 반환
+		return SeatDefinitionListResponse.from(seatDefinitions);
+	}
+}

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/builder/PerformancePricingBuilder.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/builder/PerformancePricingBuilder.java
@@ -1,18 +1,18 @@
 package wisoft.nextframe.schedulereservationticketing.builder;
 
-import wisoft.nextframe.schedulereservationticketing.entity.performance.Performance;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.PerformancePricing;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.PerformancePricingId;
+import wisoft.nextframe.schedulereservationticketing.entity.schedule.Schedule;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.StadiumSection;
 
 public class PerformancePricingBuilder {
 
-	private Performance performance = new PerformanceBuilder().build();
+	private Schedule schedule = new ScheduleBuilder().build();
 	private StadiumSection stadiumSection = new StadiumSectionBuilder().build();
 	private Integer price = 120000;
 
-	public PerformancePricingBuilder withPerformance(Performance performance) {
-		this.performance = performance;
+	public PerformancePricingBuilder withSchedule(Schedule schedule) {
+		this.schedule = schedule;
 		return this;
 	}
 
@@ -22,8 +22,8 @@ public class PerformancePricingBuilder {
 	}
 
 	public PerformancePricing build() {
-		PerformancePricingId id = new PerformancePricingId(performance.getId(), stadiumSection.getId());
+		PerformancePricingId id = new PerformancePricingId(schedule.getId(), stadiumSection.getId());
 
-		return new PerformancePricing(id, performance, stadiumSection, price);
+		return new PerformancePricing(id, schedule, stadiumSection, price);
 	}
 }

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/builder/StadiumBuilder.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/builder/StadiumBuilder.java
@@ -10,6 +10,11 @@ public class StadiumBuilder {
 	private String name = "공연장 이름";
 	private String address = "공연장 주소";
 
+	public StadiumBuilder withId(UUID id) {
+		this.id = id;
+		return this;
+	}
+
 	public StadiumBuilder withName(String name) {
 		this.name = name;
 		return this;

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/controller/performance/PerformanceControllerTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/controller/performance/PerformanceControllerTest.java
@@ -1,12 +1,8 @@
 package wisoft.nextframe.schedulereservationticketing.controller.performance;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
@@ -24,6 +20,7 @@ import wisoft.nextframe.schedulereservationticketing.builder.ScheduleBuilder;
 import wisoft.nextframe.schedulereservationticketing.builder.StadiumBuilder;
 import wisoft.nextframe.schedulereservationticketing.builder.StadiumSectionBuilder;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.Performance;
+import wisoft.nextframe.schedulereservationticketing.entity.schedule.Schedule;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.Stadium;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.StadiumSection;
 import wisoft.nextframe.schedulereservationticketing.repository.performance.PerformancePricingRepository;
@@ -58,8 +55,9 @@ class PerformanceControllerTest {
 		final StadiumSection section = stadiumSectionRepository.save(
 			new StadiumSectionBuilder().withStadium(stadium).build());
 		final Performance performance = performanceRepository.save(new PerformanceBuilder().withName("오페라의 유령").build());
-		scheduleRepository.save(new ScheduleBuilder().withPerformance(performance).withStadium(stadium).build());
-		performancePricingRepository.save(new PerformancePricingBuilder().withPerformance(performance).withStadiumSection(section).build());
+		final Schedule schedule = scheduleRepository.save(
+			new ScheduleBuilder().withPerformance(performance).withStadium(stadium).build());
+		performancePricingRepository.save(new PerformancePricingBuilder().withSchedule(schedule).withStadiumSection(section).build());
 		final UUID performanceId = performance.getId();
 
 		// when & then

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformancePricingRepositoryTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformancePricingRepositoryTest.java
@@ -12,12 +12,14 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import jakarta.transaction.Transactional;
 import wisoft.nextframe.schedulereservationticketing.builder.PerformanceBuilder;
+import wisoft.nextframe.schedulereservationticketing.builder.ScheduleBuilder;
 import wisoft.nextframe.schedulereservationticketing.builder.StadiumSectionBuilder;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.Performance;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.PerformancePricing;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.PerformancePricingId;
+import wisoft.nextframe.schedulereservationticketing.entity.schedule.Schedule;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.StadiumSection;
-import wisoft.nextframe.schedulereservationticketing.repository.stadium.StadiumRepository;
+import wisoft.nextframe.schedulereservationticketing.repository.schedule.ScheduleRepository;
 import wisoft.nextframe.schedulereservationticketing.repository.stadium.StadiumSectionRepository;
 
 @SpringBootTest
@@ -27,18 +29,18 @@ class PerformancePricingRepositoryTest {
 	@Autowired
 	private PerformancePricingRepository performancePricingRepository;
 	@Autowired
-	private PerformanceRepository performanceRepository;
+	private ScheduleRepository scheduleRepository;
 	@Autowired
 	private StadiumSectionRepository stadiumSectionRepository;
 
-	private Performance savedPerformance;
+	private Schedule savedSchedule;
 	private StadiumSection savedSection;
 
 	@BeforeEach
 	void setUp() {
 		savedSection = stadiumSectionRepository.save(new StadiumSectionBuilder().build());
 
-		savedPerformance = performanceRepository.save(new PerformanceBuilder().build());
+		savedSchedule = scheduleRepository.save(new ScheduleBuilder().build());
 	}
 
 	@Test
@@ -46,13 +48,13 @@ class PerformancePricingRepositoryTest {
 	void saveAndFindById_Success() {
 		// given
 		PerformancePricingId pricingId = PerformancePricingId.builder()
-			.performanceId(savedPerformance.getId())
+			.scheduleId(savedSchedule.getId())
 			.stadiumSectionId(savedSection.getId())
 			.build();
 
 		PerformancePricing newPricing = PerformancePricing.builder()
 			.id(pricingId)
-			.performance(savedPerformance)
+			.schedule(savedSchedule)
 			.stadiumSection(savedSection)
 			.price(180000)
 			.build();
@@ -67,7 +69,7 @@ class PerformancePricingRepositoryTest {
 		PerformancePricing foundPricing = foundPricingOptional.get();
 		assertThat(foundPricing.getId()).isEqualTo(pricingId);
 		assertThat(foundPricing.getPrice()).isEqualTo(180000);
-		assertThat(foundPricing.getPerformance().getId()).isEqualTo(savedPerformance.getId());
+		assertThat(foundPricing.getSchedule().getId()).isEqualTo(savedSchedule.getId());
 		assertThat(foundPricing.getStadiumSection().getId()).isEqualTo(savedSection.getId());
 	}
 }

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryTest.java
@@ -104,7 +104,7 @@ class PerformanceRepositoryTest {
 			.withStadium(stadium)
 			.withPerformanceDatetime(LocalDate.of(2025, 9, 1).atStartOfDay())
 			.withTicketOpenTime(now.minusDays(10))
-			.withTicketCloseTime(now.plusDays(10))
+			.withTicketCloseTime(now.plusDays(5))
 			.build()
 		);
 		scheduleRepository.save(new ScheduleBuilder()
@@ -112,7 +112,7 @@ class PerformanceRepositoryTest {
 			.withStadium(stadium)
 			.withPerformanceDatetime(LocalDate.of(2025, 9, 30).atStartOfDay())
 			.withTicketOpenTime(now.minusDays(10))
-			.withTicketCloseTime(now.plusDays(10))
+			.withTicketCloseTime(now.plusDays(5))
 			.build()
 		);
 


### PR DESCRIPTION
## 🛠️ 설명 (Description)

- 공연장(stadium)의 전체 좌석 정보를 조회하는 API를 개발합니다.

- 특정 공연장의 ID를 경로 변수(Path Variable)로 전달하여 해당 공연장에 소속된 모든 좌석의 목록을 구역(Section), 행(Row), 열(Column) 순서로 정렬하여 받아볼 수 있습니다.

## 📄 설계 문서 (Design Document)

## ✅ 테스트 계획 (Test Plan)

## 📝 변경 사항 요약 (Summary)

- DTO 정의: API 응답 스펙에 맞춘 SeatDefinitionResponse, SeatDefinitionListResponse DTO를 정의

- Repository 정의: SeatDefinitionRepository를 정의하고, JPQL @Query를 이용해 좌석을 조회하는 findAllByStadiumIdWithSorting 메서드 구현

- Service 정의: SeatDefinitionService를 추가하여 아래와 같은 비즈니스 로직을 처리했습니다.
   - 요청된 공연장의 존재 여부 검증 로직
   - Repository 호출 및 DTO 변환 로직
 
- Controller 정의: GET /api/v1/stadiums/{id}/seat-definitions 엔드포인트를 통해 Service를 호출하고 최종 응답을 반환하는 SeatDefinitionController를 구현했습니다.

## 🔗 관련 이슈 (Related Issues)

- Closed #42 


## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [x] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)
