### PR TITLE
#59 fix: 인증 필터로 인해 실패하던 공연 상세 조회 테스트 수정

### DIFF
--- a/schedule-reservation-ticketing/build.gradle
+++ b/schedule-reservation-ticketing/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    testImplementation 'org.springframework.security:spring-security-test'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/controller/performance/PerformanceControllerTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/controller/performance/PerformanceControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -49,6 +50,7 @@ class PerformanceControllerTest {
 
 	@Test
 	@DisplayName("공연 상세 조회 통합 테스트 - 성공 (200 OK)")
+	@WithMockUser
 	void getPerformanceDetail_Success() throws Exception {
 		// given
 		final Stadium stadium = stadiumRepository.save(new StadiumBuilder().withName("부산문화회관").build());
@@ -72,6 +74,7 @@ class PerformanceControllerTest {
 
 	@Test
 	@DisplayName("공연 상세 조회 통합 테스트 - 실패 (존재하지 않는 ID, 404 NOT FOUND)")
+	@WithMockUser
 	void getPerformanceDetail_NotFound() throws Exception {
 		// given
 		final UUID notExistId = UUID.randomUUID();

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryTest.java
@@ -102,7 +102,7 @@ class PerformanceRepositoryTest {
 		scheduleRepository.save(new ScheduleBuilder()
 			.withPerformance(reservablePerf)
 			.withStadium(stadium)
-			.withPerformanceDatetime(LocalDate.of(2025, 9, 1).atStartOfDay())
+			.withPerformanceDatetime(now.plusDays(30))
 			.withTicketOpenTime(now.minusDays(10))
 			.withTicketCloseTime(now.plusDays(4))
 			.build()
@@ -110,7 +110,7 @@ class PerformanceRepositoryTest {
 		scheduleRepository.save(new ScheduleBuilder()
 			.withPerformance(reservablePerf)
 			.withStadium(stadium)
-			.withPerformanceDatetime(LocalDate.of(2025, 9, 30).atStartOfDay())
+			.withPerformanceDatetime(now.plusDays(50))
 			.withTicketOpenTime(now.minusDays(10))
 			.withTicketCloseTime(now.plusDays(4))
 			.build()
@@ -127,10 +127,10 @@ class PerformanceRepositoryTest {
 			.toList();
 		assertThat(foundedPerformancList).hasSize(1);
 
-		final PerformanceSummaryResponse performanceDto = foundedPerformancList.getFirst();
-		assertThat(performanceDto.getName()).isEqualTo(uniqueName);
-		assertThat(performanceDto.getStartDate()).isEqualTo(LocalDate.of(2025, 9, 1));
-		assertThat(performanceDto.getEndDate()).isEqualTo(LocalDate.of(2025, 9, 30));
+		final PerformanceSummaryResponse performanceSummaryResponse = foundedPerformancList.getFirst();
+		assertThat(performanceSummaryResponse.getName()).isEqualTo(uniqueName);
+		assertThat(performanceSummaryResponse.getStartDate()).isEqualTo(now.plusDays(30).toLocalDate());
+		assertThat(performanceSummaryResponse.getEndDate()).isEqualTo(now.plusDays(50).toLocalDate());
 	}
 
 	@Test

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryTest.java
@@ -122,12 +122,12 @@ class PerformanceRepositoryTest {
 		// then
 		assertThat(resultPage.getContent()).isNotEmpty();
 
-		final List<PerformanceSummaryResponse> foundedPerformancList = resultPage.getContent().stream()
+		final List<PerformanceSummaryResponse> foundedPerformanceList = resultPage.getContent().stream()
 			.filter(dto -> dto.getId().equals(reservablePerf.getId()))
 			.toList();
-		assertThat(foundedPerformancList).hasSize(1);
+		assertThat(foundedPerformanceList).hasSize(1);
 
-		final PerformanceSummaryResponse performanceSummaryResponse = foundedPerformancList.getFirst();
+		final PerformanceSummaryResponse performanceSummaryResponse = foundedPerformanceList.getFirst();
 		assertThat(performanceSummaryResponse.getName()).isEqualTo(uniqueName);
 		assertThat(performanceSummaryResponse.getStartDate()).isEqualTo(now.plusDays(30).toLocalDate());
 		assertThat(performanceSummaryResponse.getEndDate()).isEqualTo(now.plusDays(50).toLocalDate());


### PR DESCRIPTION
## 🛠️ 설명 (Description)

API 전역에 인증 필터가 추가된 후, 인증 정보 없이 API를 호출하던 통합 테스트가 403 Forbidden 오류를 반환하며 실패하는 문제가 있었습니다.

실패하는 테스트 메서드에 @WithMockUser 어노테이션을 적용하여 문제를 해결했습니다. 이 어노테이션은 테스트 실행 전, 가짜 사용자 정보로 SecurityContext를 설정해주어 인증 필터를 정상적으로 통과하게 합니다.

## 📄 설계 문서 (Design Document)

## ✅ 테스트 계획 (Test Plan)

- **통합 테스트 수정**: 기존에 실패하던 `PerformanceControllerTest`의 `getPerformanceDetail_NotFound()` 테스트를 수정하여 통과시켰습니다.
- **검증 내용**: 존재하지 않는 공연 ID로 상세 조회를 요청할 때, Mock 사용자로 인증을 통과한 후 서버가 정상적으로 `404 Not Found`를 반환하는지 확인합니다.
## 📝 변경 사항 요약 (Summary)

- `PerformanceControllerTest` **수정**: 실패하는 테스트 메서드 `getPerformanceDetail_NotFound()`에 `@WithMockUser` 어노테이션 추가

## 🔗 관련 이슈 (Related Issues)

- Closed #59 
- Related None

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)
