### PR TITLE
fix payment 서버에서 schedule-reservation-ticketing 서버 분리

### DIFF
--- a/payment/src/main/java/wisoft/nextframe/payment/PaymentApplication.java
+++ b/payment/src/main/java/wisoft/nextframe/payment/PaymentApplication.java
@@ -2,12 +2,8 @@ package wisoft.nextframe.payment;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
-@ComponentScan(basePackages = {
-	"wisoft.nextframe.payment",
-	"wisoft.nextframe.schedulereservationticketing"})
 public class PaymentApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
## 🛠️ 설명 (Description)

`payment` 애플리케이션에서 `schedule-reservation-ticketing` 서버를 분리하기 위해

불필요한 `@ComponentScan` 설정을 제거했습니다.

각 모듈이 독립적으로 동작하도록 기본 스캔 전략을 따르도록 변경했습니다.

## ✅ 테스트 계획 (Test Plan)

- `payment` 서버 실행 시 정상 부팅되는지 확인
- `schedule-reservation-ticketing` 서버 실행 시 독립적으로 동작하는지 확인

## 📝 변경 사항 요약 (Summary)

- `PaymentApplication` 클래스에서 `@ComponentScan` 제거
- 모듈 간 의존성을 최소화하여 서버 분리