### PR TITLE
fix payment 모듈의 TicketAdator에서 schedule-reservation-ticketing.TicketI…

### DIFF
--- a/payment/build.gradle
+++ b/payment/build.gradle
@@ -24,8 +24,6 @@ repositories {
 }
 
 dependencies {
-    implementation project(':schedule-reservation-ticketing')
-
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'io.projectreactor:reactor-core'

--- a/payment/src/main/java/wisoft/nextframe/payment/infra/payment/adaptor/TicketIssueRequest.java
+++ b/payment/src/main/java/wisoft/nextframe/payment/infra/payment/adaptor/TicketIssueRequest.java
@@ -2,5 +2,5 @@ package wisoft.nextframe.payment.infra.payment.adaptor;
 
 import java.util.UUID;
 
-public record TicketIssueRequest(UUID reservationId ) {
+public record TicketIssueRequest(UUID reservationId) {
 }

--- a/payment/src/main/java/wisoft/nextframe/payment/infra/payment/adaptor/TicketIssueRequest.java
+++ b/payment/src/main/java/wisoft/nextframe/payment/infra/payment/adaptor/TicketIssueRequest.java
@@ -1,0 +1,6 @@
+package wisoft.nextframe.payment.infra.payment.adaptor;
+
+import java.util.UUID;
+
+public record TicketIssueRequest(UUID reservationId ) {
+}

--- a/payment/src/main/java/wisoft/nextframe/payment/infra/payment/adaptor/TicketingAdaptor.java
+++ b/payment/src/main/java/wisoft/nextframe/payment/infra/payment/adaptor/TicketingAdaptor.java
@@ -5,7 +5,6 @@ import org.springframework.web.client.RestClient;
 
 import wisoft.nextframe.payment.application.payment.port.output.TicketingClient;
 import wisoft.nextframe.payment.domain.ReservationId;
-import wisoft.nextframe.schedulereservationticketing.dto.ticketing.TicketIssueRequest;
 
 @Component
 public class TicketingAdaptor implements TicketingClient {


### PR DESCRIPTION
### 🛠️ 설명 (Description)
payment 모듈의 TicketAdaptor에서 schedule-reservation-ticketing 모듈의 TicketIssueRequest를 분리했습니다.
모듈 간 결합도를 낮추고, 독립적인 DTO를 payment 모듈 내부에 정의하여 유지보수성을 개선했습니다.

### ✅ 테스트 계획 (Test Plan)

- payment 모듈 단위 테스트 실행 (./gradlew :payment:test)
- schedule-reservation-ticketing 모듈과의 연동 시 정상 동작 확인

### 📝 변경 사항 요약 (Summary)

- payment.infra.payment.adaptor에 TicketIssueRequest DTO 생성
- 기존 참조(schedule-reservation-ticketing.TicketIssueRequest) 제거