### PR TITLE
#65 feat(payment): StubTossPaymentsAdaptor 추가 및 loadtest 환경 보안 비활성화

### DIFF
--- a/payment/src/main/java/wisoft/nextframe/payment/infra/payment/adaptor/StubTossPaymentsAdaptor.java
+++ b/payment/src/main/java/wisoft/nextframe/payment/infra/payment/adaptor/StubTossPaymentsAdaptor.java
@@ -1,0 +1,25 @@
+package wisoft.nextframe.payment.infra.payment.adaptor;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import wisoft.nextframe.payment.application.payment.port.output.TossPaymentsClient;
+
+@Component
+@Profile({"loadtest", "dev"})
+public class StubTossPaymentsAdaptor implements TossPaymentsClient {
+
+	@Override
+	public Map<String, Object> confirmPayment(String paymentKey, String orderId, int amount) {
+		// 항상 성공하는 응답을 반환
+		return Map.of(
+			"status", "DONE",
+			"paymentKey", paymentKey,
+			"orderId", orderId,
+			"approvedAt", LocalDateTime.now().toString()
+		);
+	}
+}

--- a/payment/src/main/java/wisoft/nextframe/payment/infra/payment/adaptor/TossPaymentsAdaptor.java
+++ b/payment/src/main/java/wisoft/nextframe/payment/infra/payment/adaptor/TossPaymentsAdaptor.java
@@ -5,6 +5,7 @@ import java.util.Base64;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -13,6 +14,7 @@ import org.springframework.web.client.RestClient;
 import wisoft.nextframe.payment.application.payment.port.output.TossPaymentsClient;
 
 @Component
+@Profile("prod")
 public class TossPaymentsAdaptor implements TossPaymentsClient {
 
 	private final RestClient restClient;
@@ -30,7 +32,6 @@ public class TossPaymentsAdaptor implements TossPaymentsClient {
 			.build();
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
 	public Map<String, Object> confirmPayment(String paymentKey, String orderId, int amount) {
 		return restClient.post()

--- a/payment/src/test/java/wisoft/nextframe/payment/infra/payment/adaptor/TossPaymentsStubTest.java
+++ b/payment/src/test/java/wisoft/nextframe/payment/infra/payment/adaptor/TossPaymentsStubTest.java
@@ -1,0 +1,26 @@
+package wisoft.nextframe.payment.infra.payment.adaptor;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import wisoft.nextframe.payment.application.payment.port.output.TossPaymentsClient;
+
+@SpringBootTest
+class TossPaymentsStubTest {
+
+	@Autowired
+	private TossPaymentsClient tossPaymentsClient;
+
+	@Test
+	void stubReturnsAlwaysSuccess() {
+		var result =
+			tossPaymentsClient.confirmPayment("dummy-key", "order-123", 10000);
+
+		assertThat(result.get("status")).isEqualTo("DONE");
+		assertThat(result.get("paymentKey")).isEqualTo("dummy-key");
+		assertThat(result.get("orderId")).isEqualTo("order-123");
+	}
+}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/SecurityConfig.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package wisoft.nextframe.schedulereservationticketing.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -14,6 +15,7 @@ import wisoft.nextframe.schedulereservationticketing.common.filter.JwtAuthentica
 
 @Configuration
 @EnableWebSecurity
+@Profile("!loadtest")
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/SecurityConfigForLoadTest.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/SecurityConfigForLoadTest.java
@@ -1,0 +1,20 @@
+package wisoft.nextframe.schedulereservationticketing.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@Profile("loadtest")
+public class SecurityConfigForLoadTest {
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http
+			.csrf(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+		return http.build();
+	}
+}


### PR DESCRIPTION
## 🛠️ 설명 (Description)

prod와 loadtest 프로파일에 따라 TossPaymentsAdaptor 구현체를 교체할 수 있도록 구조를 개선했습니다.
loadtest 환경에서는 StubTossPaymentsAdaptor를 사용하여 항상 성공 응답을 반환하도록 구현했습니다.
부하 테스트 환경에서 불필요한 인증 과정을 제거하여 테스트 실행이 원활하도록 보안 설정을 비활성화했습니다.

## 📄 설계 문서 (Design Document)

관련 설계 문서나 위키 페이지가 있다면 링크를 추가해주세요.(하위 항목 노션링크 첨부)

## ✅ 테스트 계획 (Test Plan)

- prod 프로파일로 실행 시 실제 Toss API 호출 정상 동작 확인
- loadtest 프로파일로 실행 시 Stub 응답 반환 및 내부 로직(트랜잭션, 티켓 발급 등) 정상 동작 확인

## 📝 변경 사항 요약 (Summary)

- StubTossPaymentsAdaptor (loadtest) 구현체 추가
- TossPaymentsAdaptor는 prod 프로파일에서만 활성화
- loadtest 프로파일 환경 보안 필터 비활성화

## 🔗 관련 이슈 (Related Issues)

- Closed #65 
- Related #이슈번호

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 테스트 코드가 작성되었고, 통과했습니다.
- [x] 변경 사항에 대한 문서화가 완료되었습니다.

