### PR TITLE
#67 fix(performance): 공연 상세 조회 시, 성인 공연 조건부 인증

### DIFF
--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/common/filter/JwtAuthenticationFilter.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/common/filter/JwtAuthenticationFilter.java
@@ -28,7 +28,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	private static final List<String> EXCLUDED_PATHS = List.of(
 		"/",
 		"/api/v1/auth/**",
-		"/api/v1/performances"
+		"/api/v1/performances/**"
 	);
 	private final AntPathMatcher pathMatcher = new AntPathMatcher();
 

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/SecurityConfig.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/SecurityConfig.java
@@ -32,7 +32,9 @@ public class SecurityConfig {
 			// HTTP 요청에 대한 접근 권한을 설정합니다.
 			.authorizeHttpRequests(authorize -> authorize
 				// 모든 사용자가 접근 가능한 경로를 지정합니다.(인증이 필요없는 접근 경로)
-				.requestMatchers("/", "/api/v1/performances", "/api/v1/auth/**").permitAll()
+				.requestMatchers("/",
+					"/api/v1/performances/**",
+					"/api/v1/auth/**").permitAll()
 				// 그 외의 모든 요청은 인증된 사용자만 접근할 수 있도록 설정합니다.
 				.anyRequest().authenticated()
 			);

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/performance/PerformanceController.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/performance/PerformanceController.java
@@ -6,15 +6,23 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import wisoft.nextframe.schedulereservationticketing.common.response.ApiResponse;
+import wisoft.nextframe.schedulereservationticketing.config.jwt.JwtTokenProvider;
 import wisoft.nextframe.schedulereservationticketing.dto.performance.performancedetail.response.PerformanceDetailResponse;
 import wisoft.nextframe.schedulereservationticketing.dto.performance.performancelist.response.PerformanceListResponse;
+import wisoft.nextframe.schedulereservationticketing.entity.user.User;
+import wisoft.nextframe.schedulereservationticketing.repository.user.UserRepository;
 import wisoft.nextframe.schedulereservationticketing.service.performance.PerformanceService;
 
 @RestController
@@ -23,13 +31,30 @@ import wisoft.nextframe.schedulereservationticketing.service.performance.Perform
 public class PerformanceController {
 
 	private final PerformanceService performanceService;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final UserRepository userRepository;
 
 	@GetMapping("/{id}")
-	public ResponseEntity<ApiResponse<?>> getPerformanceDetail(@PathVariable UUID id) {
+	public ResponseEntity<ApiResponse<?>> getPerformanceDetail(@PathVariable UUID id, HttpServletRequest request) {
 		final PerformanceDetailResponse data = performanceService.getPerformanceDetail(id);
 
-		final ApiResponse<PerformanceDetailResponse> response = ApiResponse.success(data);
+		if (data.adultOnly()) {
+			final String token = resolveToken(request);
 
+			if (token == null || !jwtTokenProvider.validateToken(token)) {
+				throw new AuthenticationCredentialsNotFoundException("유효한 인증 정보가 없습니다.");
+			}
+
+			final UUID userId = jwtTokenProvider.getUserIdFromToken(token);
+			final User user = userRepository.findById(userId)
+				.orElseThrow(() -> new EntityNotFoundException("해당 사용자를 찾을 수 없습니다."));
+
+			if (!user.isAdult()) {
+				throw new AccessDeniedException("성인 인증이 필요한 공연입니다.");
+			}
+		}
+
+		final ApiResponse<PerformanceDetailResponse> response = ApiResponse.success(data);
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 
@@ -40,5 +65,13 @@ public class PerformanceController {
 		final ApiResponse<PerformanceListResponse> response = ApiResponse.success(data);
 
 		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+
+	private String resolveToken(HttpServletRequest request) {
+		final String bearerToken = request.getHeader("Authorization");
+		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+			return bearerToken.substring(7);
+		}
+		return null;
 	}
 }

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformancePricingRepositoryTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformancePricingRepositoryTest.java
@@ -8,14 +8,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
-import jakarta.transaction.Transactional;
-import wisoft.nextframe.schedulereservationticketing.builder.PerformanceBuilder;
 import wisoft.nextframe.schedulereservationticketing.builder.ScheduleBuilder;
 import wisoft.nextframe.schedulereservationticketing.builder.StadiumSectionBuilder;
 import wisoft.nextframe.schedulereservationticketing.config.AbstractIntegrationTest;
-import wisoft.nextframe.schedulereservationticketing.entity.performance.Performance;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.PerformancePricing;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.PerformancePricingId;
 import wisoft.nextframe.schedulereservationticketing.entity.schedule.Schedule;

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryTest.java
@@ -3,9 +3,7 @@ package wisoft.nextframe.schedulereservationticketing.repository.performance;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.Duration;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -13,12 +11,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
-import jakarta.transaction.Transactional;
 import wisoft.nextframe.schedulereservationticketing.builder.PerformanceBuilder;
 import wisoft.nextframe.schedulereservationticketing.builder.ScheduleBuilder;
 import wisoft.nextframe.schedulereservationticketing.builder.StadiumBuilder;

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/schedule/ScheduleRepositoryTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/schedule/ScheduleRepositoryTest.java
@@ -10,9 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
-import jakarta.transaction.Transactional;
 import wisoft.nextframe.schedulereservationticketing.builder.PerformanceBuilder;
 import wisoft.nextframe.schedulereservationticketing.builder.StadiumBuilder;
 import wisoft.nextframe.schedulereservationticketing.config.AbstractIntegrationTest;

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/seat/SeatStateRepositoryTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/seat/SeatStateRepositoryTest.java
@@ -10,10 +10,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import jakarta.persistence.EntityManager;
-import jakarta.transaction.Transactional;
 import wisoft.nextframe.schedulereservationticketing.builder.PerformanceBuilder;
 import wisoft.nextframe.schedulereservationticketing.builder.ScheduleBuilder;
 import wisoft.nextframe.schedulereservationticketing.builder.StadiumBuilder;

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/stadium/SeatDefinitionRepositoryTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/stadium/SeatDefinitionRepositoryTest.java
@@ -9,9 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
-import jakarta.transaction.Transactional;
 import wisoft.nextframe.schedulereservationticketing.builder.StadiumBuilder;
 import wisoft.nextframe.schedulereservationticketing.builder.StadiumSectionBuilder;
 import wisoft.nextframe.schedulereservationticketing.config.AbstractIntegrationTest;

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/stadium/StadiumSectionRepositoryTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/stadium/StadiumSectionRepositoryTest.java
@@ -10,10 +10,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataIntegrityViolationException;
 
-import jakarta.transaction.Transactional;
 import wisoft.nextframe.schedulereservationticketing.builder.StadiumBuilder;
 import wisoft.nextframe.schedulereservationticketing.config.AbstractIntegrationTest;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.Stadium;

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/service/reservation/PriceCalculatorTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/service/reservation/PriceCalculatorTest.java
@@ -13,12 +13,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import wisoft.nextframe.schedulereservationticketing.builder.PerformanceBuilder;
 import wisoft.nextframe.schedulereservationticketing.builder.ScheduleBuilder;
 import wisoft.nextframe.schedulereservationticketing.builder.StadiumSectionBuilder;
-import wisoft.nextframe.schedulereservationticketing.entity.performance.Performance;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.PerformancePricing;
-import wisoft.nextframe.schedulereservationticketing.entity.performance.PerformancePricingId;
 import wisoft.nextframe.schedulereservationticketing.entity.schedule.Schedule;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.SeatDefinition;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.StadiumSection;


### PR DESCRIPTION
## 🛠️ 설명 (Description)

공연 상세 조회 API의 인증 정책을 기존의 **항상 인증**에서 **조건부 인증**으로 변경합니다.

API 명세 변경에 따라, 성인 공연을 조회할 때만 사용자 인증 및 성인 여부 검증을 수행하도록 수정했습니다. 이제 성인 공연이 아니면 비로그인 상태에서도 조회가 가능합니다.

## 📄 설계 문서 (Design Document)

## ✅ 테스트 계획 (Test Plan)

`PerformanceController`의 조건부 인증 로직을 검증하기 위해 통합 테스트를 중심으로 테스트 코드를 작성했습니다.
- 통합 테스트 (Integration Test)
   - Case 1: 성공 (일반 공연)
      - 인증 없이 일반 공연 상세 조회 시 200 OK 응답 확인
   - Case 2: 성공 (성인 공연)
      - 성인 사용자의 유효한 JWT로 성인 공연 상세 조회 시 200 OK 응답 확인
   - Case 3: 실패 (인증)
      - 인증 없이 성인 공연 상세 조회 시 401 Unauthorized 응답 확인
   - Case 4: 실패 (인가)
      - 미성년자 사용자의 JWT로 성인 공연 상세 조회 시 403 Forbidden 응답 확인


## 📝 변경 사항 요약 (Summary)

- **SecurityConfig**: `/api/v1/performances/**` 경로에 대한 접근 권한을 `permitAll()`로 변경
- **PerformanceController**: `getPerformanceDetail` 메서드에 공연의 `adult_only` 플래그를 확인하여 조건부로 JWT를 검증하는 로직 추가
- `JwtAuthenticationFilter`: 인증 필터에서 `/api/v1/performances/**` 경로는 제외

## 🔗 관련 이슈 (Related Issues)

- Closed #67 

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

이번 작업에서 인증/인가 로직을 Service 레이어가 아닌 Controller에 구현했습니다.

이는 Service 레이어는 HttpServletRequest와 같은 웹 계층 기술에 의존하지 않고 순수한 비즈니스 로직에 집중해야 한다는 역할과 책임 분리(SoC) 원칙을 따르기 위함입니다. 컨트롤러가 인증에 필요한 정보(토큰)와 비즈니스 정보(성인 공연 여부)를 모두 갖게 되는 첫 지점이므로, 컨트롤러에서 처리하는 것이 가장 적합하다고 판단했습니다.

## ➕ 추가 정보 (Additional Information)
