### PR TITLE
#71 refactor(reservation): 토큰 기반으로 예약자 정보 처리 변경

### DIFF
--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/common/filter/JwtAuthenticationFilter.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/common/filter/JwtAuthenticationFilter.java
@@ -84,5 +84,4 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		}
 		return null;
 	}
-
 }

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/reservation/ReservationController.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/reservation/ReservationController.java
@@ -1,7 +1,10 @@
 package wisoft.nextframe.schedulereservationticketing.controller.reservation;
 
+import java.util.UUID;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,8 +25,12 @@ public class ReservationController {
 	private final ReservationService reservationService;
 
 	@PostMapping
-	public ResponseEntity<ApiResponse<?>> reserveSeat(@Valid @RequestBody ReservationRequest request) {
-		final ReservationResponse reservationResponse = reservationService.reserveSeat(request);
+	public ResponseEntity<ApiResponse<?>> reserveSeat(
+		@AuthenticationPrincipal UUID userId,
+		@Valid @RequestBody ReservationRequest request
+	) {
+		final ReservationResponse reservationResponse = reservationService.reserveSeat(userId, request);
+
 		final ApiResponse<ReservationResponse> response = ApiResponse.success(reservationResponse);
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/dto/reservation/request/ReservationRequest.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/dto/reservation/request/ReservationRequest.java
@@ -6,8 +6,12 @@ import java.util.UUID;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
 
-public record ReservationRequest(@NotNull UUID userId, @NotNull UUID performanceId, @NotNull UUID scheduleId,
-																 @NotEmpty @Size(max = 4) List<UUID> seatIds, long elapsedTime, int totalAmount) {
+public record ReservationRequest(
+	@NotNull UUID performanceId,
+	@NotNull UUID scheduleId,
+  @NotEmpty @Size(max = 4) List<UUID> seatIds,
+	long elapsedTime,
+	int totalAmount
+) {
 }

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationDataProvider.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationDataProvider.java
@@ -1,6 +1,7 @@
 package wisoft.nextframe.schedulereservationticketing.service.reservation;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.stereotype.Component;
 
@@ -13,7 +14,6 @@ import wisoft.nextframe.schedulereservationticketing.entity.stadium.SeatDefiniti
 import wisoft.nextframe.schedulereservationticketing.entity.user.User;
 import wisoft.nextframe.schedulereservationticketing.exception.reservation.InvalidSeatCountException;
 import wisoft.nextframe.schedulereservationticketing.exception.reservation.PerformanceScheduleMismatchException;
-import wisoft.nextframe.schedulereservationticketing.exception.reservation.ReservationException;
 import wisoft.nextframe.schedulereservationticketing.exception.reservation.SeatNotDefinedException;
 import wisoft.nextframe.schedulereservationticketing.repository.schedule.ScheduleRepository;
 import wisoft.nextframe.schedulereservationticketing.repository.stadium.SeatDefinitionRepository;
@@ -28,14 +28,14 @@ public class ReservationDataProvider {
 	private final SeatDefinitionRepository seatDefinitionRepository;
 
 	/**
-	 * ReservationRequest를 기반으로 예매에 필요한 모든 엔티티를 조회하고 검증하여
+	 * userId, ReservationRequest를 기반으로 예매에 필요한 모든 엔티티를 조회하고 검증하여
 	 * ReservationContext 객체로 반환합니다.
 	 * @param request 예매 요청 DTO
 	 * @return 예매 컨텍스트 객체
 	 */
-	public ReservationContext provide(ReservationRequest request) {
+	public ReservationContext provide(UUID userId, ReservationRequest request) {
 		// 1. 각 ID를 사용하여 엔티티를 조회합니다.
-		final User user = userRepository.findById(request.userId())
+		final User user = userRepository.findById(userId)
 			.orElseThrow(() -> new EntityNotFoundException("해당 사용자를 찾을 수 없습니다."));
 
 		final Schedule schedule = scheduleRepository.findById(request.scheduleId())

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationService.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationService.java
@@ -1,6 +1,7 @@
 package wisoft.nextframe.schedulereservationticketing.service.reservation;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,9 +29,9 @@ public class ReservationService {
 	private final ReservationDataProvider dataProvider;
 
 	@Transactional
-	public ReservationResponse reserveSeat(ReservationRequest request) {
+	public ReservationResponse reserveSeat(UUID userId, ReservationRequest request) {
 		// 1. 예매에 필요한 데이터를 준비합니다.
-		final ReservationContext context = dataProvider.provide(request);
+		final ReservationContext context = dataProvider.provide(userId, request);
 		final Performance performance = context.performance();
 		final User user = context.user();
 		final List<SeatDefinition> seats = context.seats();


### PR DESCRIPTION
## 🛠️ 설명 (Description)

공연 좌석 예약 API의 사용자 인증 방식을 개선합니다.

기존에는 예약 요청의 Body에 `userId`를 직접 포함하여 사용자를 식별했으나, 이 방식은 보안에 취약하고 데이터의 중복을 유발할 수 있습니다.

이번 변경을 통해 `Authorization` 헤더의 JWT 토큰에서 사용자 정보를 추출하여 처리하도록 리팩토링했습니다. 이를 통해 API의 보안성을 강화하고, 클라이언트의 요청 구조를 더 명확하게 개선합니다.

## 📄 설계 문서 (Design Document)

## ✅ 테스트 계획 (Test Plan)

통합 테스트 (Integration Test)
- 성공 케이스: 유효한 JWT 토큰과 함께 예약 요청 시, `201 CREATED` 응답과 함께 해당 사용자의 예약 정보가 정상적으로 생성되는지 확인합니다.
- 실패 케이스 1: JWT 토큰 없이 예약 요청 시, `401 Unauthorized` 또는 `403 Forbidden` 응답이 반환되는지 확인합니다.
- 실패 케이스 2: 유효하지 않은 (만료되거나 서명이 위조된) JWT 토큰으로 예약 요청 시, `401 Unauthorized` 또는 `403 Forbidden` 응답이 반환되는지 확인합니다.

## 📝 변경 사항 요약 (Summary)

- `ReservationController`: `@AuthenticationPrincipal`을 사용하여 토큰에서 직접 `userId`를 주입받도록 변경
- `ReservationService`: `userId`를 파라미터로 명시적으로 받아 비즈니스 로직을 처리하도록 수정
- `ReservationRequest` **DTO**: 요청 Body에서 불필요해진 `userId` 필드 제거

## 🔗 관련 이슈 (Related Issues)

- Closed #71 

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

이번 변경의 핵심은 `JwtAuthenticationFilter`가 `SecurityContext`에 `userId`를 저장하고, 컨트롤러가 `@AuthenticationPrincipal`로 이를 꺼내 쓰는 흐름입니다.

서비스 로직이 더 이상 `HttpServletRequest`나 DTO의 `userId`에 의존하지 않고, 인증된 사용자 정보에만 의존하도록 변경되었습니다.

## ➕ 추가 정보 (Additional Information)
