### PR TITLE
#77 chore: 모노레포 CD 워크플로우 구성

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,150 @@
+name: API Server CD
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  # 첫 번째 작업: 어떤 모듈의 파일이 변경되었는지 감지합니다.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      # 이 작업의 결과를 다른 작업에서 사용할 수 있도록 'outputs'으로 정의합니다.
+      payment: ${{ steps.filter.outputs.payment_any_changed }}
+      srt: ${{ steps.filter.outputs.srt_any_changed }}
+    steps:
+      - name: 레포지토리 체크아웃
+        uses: actions/checkout@v4
+        with:
+          # Git 히스토리를 모두 가져와서 변경된 파일을 정확히 비교할 수 있도록 합니다.
+          fetch-depth: 0
+
+      # tj-actions/changed-files 액션을 사용하여 변경된 파일을 감지합니다.
+      - name: 변경된 파일 감지
+        id: filter # 이 스텝의 결과를 'filter'라는 ID로 참조할 수 있습니다.
+        uses: tj-actions/changed-files@v42
+        with:
+          # 감지할 모듈과 파일 경로를 지정합니다.
+          files_yaml: |
+            payment:
+              - payment/**
+            srt:
+              - schedule-reservation-ticketing/**
+          # 마지막 원격 커밋 이후의 변경사항을 기준으로 감지합니다.
+          since_last_remote_commit: true
+
+  deploy-payment:
+    # 'changes' 작업이 성공적으로 완료되어야 이 작업을 시작합니다.
+    needs: changes
+    # 'changes' 작업의 출력값 'payment'가 'true'일 때만 이 작업을 실행합니다. (조건부 실행)
+    if: needs.changes.outputs.payment == 'true'
+    runs-on: ubuntu-latest
+
+    env:
+      APP_DIR: '~/next-frame/app/payment-api'
+      JAR_NAME: 'payment.jar'
+
+    steps:
+      - name: 소스 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: JDK 21 설치
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Gradle 실행 권한 부여
+        run: chmod +x ./gradlew
+
+      - name: payment 모듈 빌드
+        run: ./gradlew :payment:build -x test
+
+      - name: SSH Agent 셋업
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: SSH 파일 저장
+        run: |
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > /tmp/new_id
+          chmod 600 /tmp/new_id
+
+      - name: Bastion 서버 연결 테스트
+        run: |
+          ssh -o StrictHostKeyChecking=no -i /tmp/new_id ${{secrets.BASTION_USER}}@${{secrets.BASTION_HOST}} -p 10020 "echo Bastion 서버 연결 성공"
+
+      - name: 빌드 파일 애플리케이션 서버로 복사
+        run: |
+          scp -o StrictHostKeyChecking=no -i /tmp/new_id \
+              -J ${{ secrets.BASTION_USER }}@${{ secrets.BASTION_HOST }}:10020 \
+              payment/build/libs/*-SNAPSHOT.jar \
+              ${{ secrets.DAISY04_USER }}@${{ secrets.DAISY04_HOST }}:${{ env.APP_DIR }}/
+
+      - name: 애플리케이션 서버에 변경 사항 적용
+        run: |
+          ssh -o StrictHostKeyChecking=no -i /tmp/new_id \
+              -J ${{ secrets.BASTION_USER }}@${{ secrets.BASTION_HOST }}:${{ secrets.BASTION_PORT }} \
+              ${{ secrets.DAISY04_USER }}@${{ secrets.DAISY04_HOST }} '
+              mv ${{ env.APP_DIR }}/*-SNAPSHOT.jar ${{ env.APP_DIR }}/payment.jar &&
+              sudo systemctl restart nextframe-payment
+          '
+
+  deploy-schedule-reservation-ticketing:
+    # 'changes' 작업이 성공적으로 완료되어야 이 작업을 시작합니다.
+    needs: changes
+    # 'changes' 작업의 출력값 'payment'가 'true'일 때만 이 작업을 실행합니다. (조건부 실행)
+    if: needs.changes.outputs.srt == 'true'
+    runs-on: ubuntu-latest
+
+    env:
+      APP_DIR: '~/next-frame/app/srt-api'
+      JAR_NAME: 'schedule-reservation-ticketing.jar'
+
+    steps:
+      - name: 소스 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: JDK 21 설치
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Gradle 실행 권한 부여
+        run: chmod +x ./gradlew
+
+      - name: schedule-reservation-ticketing 모듈 빌드
+        run: ./gradlew :schedule-reservation-ticketing:build -x test
+
+      - name: SSH Agent 설정
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: SSH 파일 저장
+        run: |
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > /tmp/new_id
+          chmod 600 /tmp/new_id
+
+      - name: Bastion 서버 연결 테스트
+        run: |
+          ssh -o StrictHostKeyChecking=no -i /tmp/new_id ${{secrets.BASTION_USER}}@${{secrets.BASTION_HOST}} -p 10020 "Bastion 중간 서버 연결 성공"
+
+      - name: 빌드 파일 애플리케이션 서버로 복사
+        run: |
+          scp -o StrictHostKeyChecking=no -i /tmp/new_id \
+              -J ${{ secrets.BASTION_USER }}@${{ secrets.BASTION_HOST }}:10020 \
+              schedule-reservation-ticketing/build/libs/*-SNAPSHOT.jar \
+              ${{ secrets.DAISY04_USER }}@${{ secrets.DAISY04_HOST }}:${{ env.APP_DIR }}/
+
+
+      - name: 애플리케이션 서버에 변경 사항 적용
+        run: |
+          ssh -o StrictHostKeyChecking=no -i /tmp/new_id \
+              -J ${{ secrets.BASTION_USER }}@${{ secrets.BASTION_HOST }}:${{ secrets.BASTION_PORT }} \
+              ${{ secrets.DAISY04_USER }}@${{ secrets.DAISY04_HOST }} '
+              mv ${{ env.APP_DIR }}/*-SNAPSHOT.jar ${{ env.APP_DIR }}/schedule-reservation-ticketing.jar &&
+              sudo systemctl restart nextframe-srt
+            '

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -73,12 +73,12 @@ jobs:
 
       - name: Bastion 서버 연결 테스트
         run: |
-          ssh -o StrictHostKeyChecking=no -i /tmp/new_id ${{secrets.BASTION_USER}}@${{secrets.BASTION_HOST}} -p 10020 "echo Bastion 서버 연결 성공"
+          ssh -o StrictHostKeyChecking=no -i /tmp/new_id ${{secrets.BASTION_USER}}@${{secrets.BASTION_HOST}} -p ${{ secrets.BASTION_PORT }} "echo \"Bastion 중간 서버 연결 성공\""
 
       - name: 빌드 파일 애플리케이션 서버로 복사
         run: |
           scp -o StrictHostKeyChecking=no -i /tmp/new_id \
-              -J ${{ secrets.BASTION_USER }}@${{ secrets.BASTION_HOST }}:10020 \
+              -J ${{ secrets.BASTION_USER }}@${{ secrets.BASTION_HOST }}:${{ secrets.BASTION_PORT }} \
               payment/build/libs/*-SNAPSHOT.jar \
               ${{ secrets.DAISY04_USER }}@${{ secrets.DAISY04_HOST }}:${{ env.APP_DIR }}/
 
@@ -94,7 +94,7 @@ jobs:
   deploy-schedule-reservation-ticketing:
     # 'changes' 작업이 성공적으로 완료되어야 이 작업을 시작합니다.
     needs: changes
-    # 'changes' 작업의 출력값 'payment'가 'true'일 때만 이 작업을 실행합니다. (조건부 실행)
+    # 'changes' 작업의 출력값 'schedule-reservation-ticketing'가 'true'일 때만 이 작업을 실행합니다. (조건부 실행)
     if: needs.changes.outputs.srt == 'true'
     runs-on: ubuntu-latest
 
@@ -130,12 +130,12 @@ jobs:
 
       - name: Bastion 서버 연결 테스트
         run: |
-          ssh -o StrictHostKeyChecking=no -i /tmp/new_id ${{secrets.BASTION_USER}}@${{secrets.BASTION_HOST}} -p 10020 "Bastion 중간 서버 연결 성공"
+          ssh -o StrictHostKeyChecking=no -i /tmp/new_id ${{secrets.BASTION_USER}}@${{secrets.BASTION_HOST}} -p ${{ secrets.BASTION_PORT }} "echo \"Bastion 중간 서버 연결 성공\""
 
       - name: 빌드 파일 애플리케이션 서버로 복사
         run: |
           scp -o StrictHostKeyChecking=no -i /tmp/new_id \
-              -J ${{ secrets.BASTION_USER }}@${{ secrets.BASTION_HOST }}:10020 \
+              -J ${{ secrets.BASTION_USER }}@${{ secrets.BASTION_HOST }}:${{ secrets.BASTION_PORT }} \
               schedule-reservation-ticketing/build/libs/*-SNAPSHOT.jar \
               ${{ secrets.DAISY04_USER }}@${{ secrets.DAISY04_HOST }}:${{ env.APP_DIR }}/
 


### PR DESCRIPTION
## 🛠️ 설명 (Description)

GitHub Actions를 사용하여 모노레포 환경의 CD(지속적 배포) 파이프라인을 구축했습니다.

`main` 브랜치에 코드가 푸시되면, 특정 디렉터리의 파일 변경을 감지하여 변경된 모듈(`payment`, `schedule-reservation-ticketing`)만 독립적으로 빌드하고 배포하는 워크플로우를 구현했습니다.

베스천 호스트를 경유하는 배포 환경의 안정성을 높이기 위해, 동적으로 SSH 설정 파일을 생성하여 ProxyJump 연결을 처리하도록 구성했습니다.

## 📄 설계 문서 (Design Document)

## ✅ 테스트 계획 (Test Plan)

`test-cd-workflow` 브랜치를 생성하여 실제 배포 과정과 동일한 조건으로 테스트를 완료했습니다.
- Case 1: `payment` 모듈만 수정 후 푸시 → `deploy-payment` Job만 실행 확인
- Case 2: `schedule-reservation-ticketing` 모듈만 수정 후 푸시 → `deploy-schedule-reservation-ticketing` Job만 실행 확인
- Case 3: 모듈과 관련 없는 파일 수정 후 푸시 → 두 배포 Job이 모두 스킵되는 것 확인

## 📝 변경 사항 요약 (Summary)

- `.github/workflows/cd.yml` 워크플로우 파일 신규 생성
- `tj-actions/changed-files` Action을 사용하여 변경된 모듈을 감지하는 `check-changes` Job 추가
- 각 모듈(`payment`, `schedule-reservation-ticketing`)에 대한 `deploy-*` Job 구성 (빌드, 배포, 재시작)
- 배포에 필요한 Secret(`BASTION_HOST`, `DAISY04_HOST`, `SSH_PRIVATE_KEY` 등) 정의 및 사용

## 🔗 관련 이슈 (Related Issues)

- Closed #77 

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [x] 변경 사항에 대한 문서화가 완료되었습니다.
- [x] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)
