### PR TITLE
#93 feat(loadtest): Reservation 전용 부하테스트 Controller API 추가

### DIFF
--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/reservation/ReservationControllerForLoadTest.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/reservation/ReservationControllerForLoadTest.java
@@ -1,0 +1,37 @@
+package wisoft.nextframe.schedulereservationticketing.controller.reservation;
+
+import java.util.UUID;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import wisoft.nextframe.schedulereservationticketing.common.response.ApiResponse;
+import wisoft.nextframe.schedulereservationticketing.dto.reservation.request.ReservationRequest;
+import wisoft.nextframe.schedulereservationticketing.dto.reservation.response.ReservationResponse;
+import wisoft.nextframe.schedulereservationticketing.service.reservation.ReservationService;
+
+@Profile("loadtest")
+@RestController
+@RequestMapping("/api/v1/loadtest/reservations")
+@RequiredArgsConstructor
+public class ReservationControllerForLoadTest {
+
+    private final ReservationService reservationService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<?>> reserveSeat(
+        @RequestHeader("X-USER-ID") UUID userId,  // loadtest 환경에서는 헤더에서 받음
+        @Valid @RequestBody ReservationRequest request
+    ) {
+        final ReservationResponse reservationResponse = reservationService.reserveSeat(userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(reservationResponse));
+    }
+}


### PR DESCRIPTION
## 🛠️ 설명 (Description)

- `@Profile("loadtest")` 전용 `ReservationControllerForLoadTest` 추가
- `POST /api/v1/loadtest/reservations` 엔드포인트 구현
- 부하 테스트 환경에서는 `X-USER-ID` 헤더로 사용자 식별자를 전달받도록 변경

## ✅ 테스트 계획 (Test Plan)

- `loadtest` 프로파일 실행 시 정상적으로 API 호출 가능 여부 확인
- nGrinder 등 부하테스트 도구로 대량 요청 시 좌석 예약 로직 정상 동작 검증

## 📝 변경 사항 요약 (Summary)

- ReservationControllerForLoadTest 클래스 추가
- `X-USER-ID` 헤더 기반 예약 API 작성
- 응답은 기존 `ApiResponse.success(reservationResponse)` 포맷 유지

## 🔗 관련 이슈 (Related Issues)

- Closed #93 
- Related #이슈번호

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 테스트 코드가 작성되었고, 통과했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

본 컨트롤러는 loadtest 환경 전용이며, 실제 서비스 운영 환경(prod)에는 영향을 주지 않습니다.
