### PR TITLE
#102 fix(reservation): 비관적 락으로 중복 예약 방지

### DIFF
--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/reservation/ReservationSeat.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/reservation/ReservationSeat.java
@@ -7,16 +7,25 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import wisoft.nextframe.schedulereservationticketing.entity.schedule.Schedule;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.SeatDefinition;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "reservation_seats")
+@Table(name = "reservation_seats",
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "uq_reservation_seats_schedule_seat",
+			columnNames = {"schedule_id", "seat_id"}
+		)
+	}
+)
 public class ReservationSeat {
 
 	@EmbeddedId
@@ -33,9 +42,14 @@ public class ReservationSeat {
 	@JoinColumn(name = "seat_id")
 	private SeatDefinition seatDefinition;
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "schedule_id", nullable = false)
+	private Schedule schedule;
+
 	public ReservationSeat(Reservation reservation, SeatDefinition seatDefinition) {
 		this.reservation = reservation;
 		this.seatDefinition = seatDefinition;
+		this.schedule = reservation.getSchedule();
 		this.id = new ReservationSeatId(reservation.getId(), seatDefinition.getId());
 	}
 }

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/seat/SeatState.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/seat/SeatState.java
@@ -39,4 +39,8 @@ public class SeatState {
 
 	@Column(name = "is_locked", nullable = false)
 	private Boolean isLocked;
+
+	public void lock() {
+		this.isLocked = true;
+	}
 }

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/seat/SeatStateRepository.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/seat/SeatStateRepository.java
@@ -4,46 +4,29 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import jakarta.persistence.LockModeType;
 import wisoft.nextframe.schedulereservationticketing.entity.seat.SeatState;
 import wisoft.nextframe.schedulereservationticketing.entity.seat.SeatStateId;
 
 public interface SeatStateRepository extends JpaRepository<SeatState, SeatStateId> {
 
 	/**
-	 * 주어진 스케줄의 좌석 ID 목록에 대해 잠긴(isLocked = true) 좌석이 하나라도 있는지 확인합니다.
+	 * [수정됨] 주어진 스케줄과 좌석 ID 목록에 해당하는 SeatState 엔티티를 비관적 쓰기 락을 걸어 조회합니다.
+	 * 이 메서드는 트랜잭션 내에서 호출되어야 합니다.
 	 * @param scheduleId 스케줄 ID
 	 * @param seatIds 좌석 ID 목록
-	 * @return 잠긴 좌석이 있으면 true, 없으면 false
+	 * @return 잠금이 적용된 SeatState 엔티티 목록
 	 */
-	@Query("""
-			SELECT EXISTS (
-				SELECT 1
-					FROM SeatState ss
-					WHERE ss.id.scheduleId = :scheduleId
-					AND ss.id.seatId IN :seatIds
-					AND ss.isLocked = TRUE
-				)
-	""")
-	boolean existsByScheduleIdSeatIsLocked(@Param("scheduleId") UUID scheduleId, @Param("seatIds") List<UUID> seatIds);
-
-	/**
-	 * 주어진 스케줄과 좌석 ID 목록에 해당하는 좌석들을 잠금 상태(isLocked = true)로 변경합니다.
-	 * @param scheduleId 스케줄 ID
-	 * @param seatIds 좌석 ID 목록
-	 * @return 변경된 좌석 수
-	 */
-	@Modifying
-	@Query("""
-				update SeatState ss
-				set ss.isLocked = true
-				where ss.id.scheduleId = :scheduleId
-				and ss.id.seatId in :seatIds
-		""")
-	int lockSeats(@Param("scheduleId") UUID scheduleId, @Param("seatIds") List<UUID> seatIds);
+	@Lock(LockModeType.PESSIMISTIC_FORCE_INCREMENT)
+	@Query("SELECT ss FROM SeatState ss WHERE ss.id.scheduleId = :scheduleId AND ss.id.seatId IN :seatIds")
+	List<SeatState> findAndLockByScheduleIdAndSeatIds(
+		@Param("scheduleId") UUID scheduleId,
+		@Param("seatIds") List<UUID> seatIds
+	);
 
 	/**
 	 * 특정 스케줄 ID에 대해 잠겨 있는(isLocked=true) 모든 좌석 상태를 조회합니다.


### PR DESCRIPTION
## 🛠️ 설명 (Description)

부하 테스트에서 발견된 좌석 중복 예약 문제를 해결합니다.

기존 로직은 좌석 상태를 확인하고 예매하는 과정이 분리되어 있어, 동시 요청 시 동일 좌석에 여러 개의 예약이 성공하는 경쟁 상태(Race Condition)가 발생했습니다.

이 PR은 비관적 락(Pessimistic Lock)을 도입하여 좌석 조회와 잠금을 원자적으로 처리하고, 데이터베이스에 UNIQUE 제약 조건을 추가하여 데이터 정합성을 다층으로 보장합니다.

## 📄 설계 문서 (Design Document)

## ✅ 테스트 계획 (Test Plan)

- 통합 테스트 (Integration Test)
   - SeatStateRepositoryTest.java를 수정하여, 좌석 조회 시 PESSIMISTIC_FORCE_INCREMENT 락이 정상적으로 적용되는지 EntityManager.getLockMode()를 통해 검증했습니다.

- 부하 테스트 (Load Test)
   - 기존에 문제를 재현했던 시나리오(동일 좌석 동시 요청)를 nGrinder 재실행하여, 중복 예약이 더 이상 발생하지 않음을 확인했습니다.

## 📝 변경 사항 요약 (Summary)

- DB 스키마 변경: reservation_seats 테이블에 schedule_id 및 UNIQUE 제약 조건 추가
- JPA 엔티티 수정: 스키마 변경에 따라 ReservationSeat 엔티티 업데이트
- 동시성 제어 로직 추가: SeatStateRepository에 비관적 락(@Lock)을 적용한 조회 메서드 추가
- 도메인 로직 리팩토링: Schedule의 좌석 잠금 로직을 원자적 방식으로 변경
- 테스트 코드 수정: 변경된 Repository 로직을 검증하는 통합 테스트 코드 업데이트

## 🔗 관련 이슈 (Related Issues)

- Closed #102 

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 테스트 코드가 작성되었고, 통과했습니다.
- [x] 변경 사항에 대한 문서화가 완료되었습니다.
- [x] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)
이 PR의 핵심은 SeatStateRepository에 추가된 findAndLockByScheduleIdAndSeatIds 메서드와 이를 사용하는 Schedule의 lockSeatsForReservation 로직입니다. @Lock(LockModeType.PESSIMISTIC_WRITE)를 통해 데이터베이스 레벨에서 잠금을 설정하여 경쟁 상태를 해결했습니다.

## ➕ 추가 정보 (Additional Information)
