### PR TITLE
#107 improvement(seat): 공연장 좌석 조회 API 성능 개선

### DIFF
--- a/schedule-reservation-ticketing/build.gradle
+++ b/schedule-reservation-ticketing/build.gradle
@@ -52,6 +52,10 @@ dependencies {
     // Testcontainers (통합 테스트용)
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:postgresql'
+
+    // Cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 }
 
 tasks.named('test') {

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/ScheduleReservationTicketingApplication.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/ScheduleReservationTicketingApplication.java
@@ -3,7 +3,9 @@ package wisoft.nextframe.schedulereservationticketing;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cache.annotation.EnableCaching;
 
+@EnableCaching
 @SpringBootApplication
 @ConfigurationPropertiesScan
 public class ScheduleReservationTicketingApplication {

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationService.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationService.java
@@ -3,6 +3,7 @@ package wisoft.nextframe.schedulereservationticketing.service.reservation;
 import java.util.List;
 import java.util.UUID;
 
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +31,7 @@ public class ReservationService {
 	private final ReservationFactory reservationFactory;
 	private final ReservationDataProvider dataProvider;
 
+	@CacheEvict(cacheNames = "seatStates", key = "#request.scheduleId")
 	@Transactional
 	public ReservationResponse reserveSeat(UUID userId, ReservationRequest request) {
 		log.debug("좌석 예매 서비스 시작. userId: {}, scheduleId: {}", userId, request.scheduleId());

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/seat/SeatStateService.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/seat/SeatStateService.java
@@ -3,6 +3,7 @@ package wisoft.nextframe.schedulereservationticketing.service.seat;
 import java.util.List;
 import java.util.UUID;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +21,7 @@ public class SeatStateService {
 	
 	private final SeatStateRepository seatStateRepository;
 
+	@Cacheable(cacheNames = "seatStates", key = "#scheduleId")
 	public SeatStateListResponse getSeatStates(UUID scheduleId) {
 		log.debug("DB에서 잠긴 좌석 조회 시작. scheduleId: {}", scheduleId);
 		// 1. 공연 일정(scheduleId)에 해당하는 잠긴(예약된) 좌석 엔티티 목록을 조회합니다.


### PR DESCRIPTION
## 🛠️ 설명 (Description)

'공연장 좌석 상태 조회 API'의 성능 저하 문제를 해결하기 위해 서버 사이드 캐시를 적용했습니다.

부하 테스트 시 확인된 주기적인 TPS 급락 및 응답 시간 급증 현상의 원인이 과도한 객체 생성으로 인한 Full GC 발생임을 확인했습니다. 이 문제를 해결하기 위해 DB 조회 및 객체 생성 자체를 최소화하는 캐싱 전략을 도입하여 애플리케이션의 안정성과 처리량을 대폭 향상시켰습니다.

## 📄 설계 문서 (Design Document)

[API 성능 개선 분석](https://next-frame.notion.site/2-Spring-Cache-2899bdd36eb28028890aec5d3f85a00c?source=copy_link)

## ✅ 테스트 계획 (Test Plan)

- nGrinder 부하 테스트 (Before & After)
   - Before: 캐시 적용 전, 동일한 시나리오로 부하 테스트를 진행하여 베이스라인 성능 데이터 확보 및 문제 현상(주기적 TPS 급락) 재현.
   - After: 캐시 적용 후, 동일한 시나리오로 부하 테스트를 재수행하여 TPS, 응답 시간, GC 로그를 비교 분석.
   - 결과: 최대 TPS 167% 향상 및 Full GC 문제 완전 해결 확인.

## 📝 변경 사항 요약 (Summary)

- build.gradle: spring-boot-starter-cache, caffeine 의존성 추가
- ScheduleReservationTicketingApplication.java: @EnableCaching 어노테이션 추가로 캐시 기능 활성화
- application.yml: seatStates 캐시 이름 및 정책(만료 시간, 최대 사이즈) 설정
- SeatStateService: 좌석 조회 메서드에 @Cacheable 적용
- ReservationService: 좌석 예매 메서드에 @CacheEvict를 적용하여 데이터 정합성 보장

## 🔗 관련 이슈 (Related Issues)

- Closed #107 

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [x] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

이번 PR의 핵심은 SeatStateService의 조회 로직과 ReservationService의 예매 로직이 캐시를 통해 어떻게 상호작용하는지 확인하는 것입니다. 특히 예매가 성공했을 때, 트랜잭션 커밋 후 @CacheEvict가 정상적으로 동작하여 캐시를 비워주는 로직을 중점적으로 검토해주시면 감사하겠습니다.

## ➕ 추가 정보 (Additional Information)
