### PR TITLE
#109 feat(performance): 인기 공연 목록 조회 API 개발

### DIFF
--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/performance/PerformanceController.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/performance/PerformanceController.java
@@ -22,6 +22,7 @@ import wisoft.nextframe.schedulereservationticketing.common.response.ApiResponse
 import wisoft.nextframe.schedulereservationticketing.config.jwt.JwtTokenProvider;
 import wisoft.nextframe.schedulereservationticketing.dto.performance.performancedetail.response.PerformanceDetailResponse;
 import wisoft.nextframe.schedulereservationticketing.dto.performance.performancelist.response.PerformanceListResponse;
+import wisoft.nextframe.schedulereservationticketing.dto.performance.performancelist.response.Top10PerformanceListResponse;
 import wisoft.nextframe.schedulereservationticketing.entity.user.User;
 import wisoft.nextframe.schedulereservationticketing.repository.user.UserRepository;
 import wisoft.nextframe.schedulereservationticketing.service.performance.PerformanceService;
@@ -74,6 +75,16 @@ public class PerformanceController {
 		final ApiResponse<PerformanceListResponse> response = ApiResponse.success(data);
 		log.info("공연 목록 조회 성공. 반환된 공연 수: {}", data.performances().size());
 		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+
+	@GetMapping("/top10")
+	public ResponseEntity<ApiResponse<?>> getTop10Performances() {
+		log.info("인기 공연 TOP 10 조회 요청.");
+		final Top10PerformanceListResponse data = performanceService.getTop10Performances();
+
+		final ApiResponse<Top10PerformanceListResponse> response = ApiResponse.success(data);
+		log.info("인기 공연 TOP 10 조회 성공.");
+		return ResponseEntity.ok(response);
 	}
 
 	private String resolveToken(HttpServletRequest request) {

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/dto/performance/performancelist/response/Top10PerformanceListResponse.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/dto/performance/performancelist/response/Top10PerformanceListResponse.java
@@ -1,0 +1,8 @@
+package wisoft.nextframe.schedulereservationticketing.dto.performance.performancelist.response;
+
+import java.util.List;
+
+public record Top10PerformanceListResponse(
+	List<PerformanceSummaryResponse> performances
+) {
+}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/performance/PerformanceStatistic.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/performance/PerformanceStatistic.java
@@ -1,0 +1,46 @@
+package wisoft.nextframe.schedulereservationticketing.entity.performance;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Entity
+@Table(name = "performance_statistics")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PerformanceStatistic {
+
+	@Id
+	@Column(name = "performance_id", nullable = false)
+	private UUID performanceId;
+
+	@Column(name = "hit")
+	private Integer hit;
+
+	@Column(name = "average_star", precision = 2, scale = 1)
+	private BigDecimal averageStar;
+
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@MapsId
+	@JoinColumn(name = "performance_id")
+	private Performance performance;
+}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepository.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepository.java
@@ -48,4 +48,38 @@ public interface PerformanceRepository extends JpaRepository<Performance, UUID> 
 				GROUP BY p.id, p.name, p.imageUrl, p.type, p.genre, st.name, p.adultOnly
 		""")
 	Page<PerformanceSummaryResponse> findReservablePerformances(Pageable pageable);
+
+	/**
+	 * 조회수(hit)가 높은 인기 공연 10개를 DTO로 직접 조회합니다.
+	 *
+	 * 이 메소드는 다음 조건을 만족하는 공연을 찾습니다.
+	 * - PerformanceStatistic 테이블과 JOIN하여 hit 정보를 가져옵니다.
+	 * - GROUP BY를 사용하여 각 공연의 시작일과 종료일을 계산합니다.
+	 * - HAVING 절을 사용하여 공연의 마지막 날짜가 현재보다 이전인(종료된) 공연은 제외합니다.
+	 * - ORDER BY 절을 통해 조회수(hit)로 내림차순 정렬하고, 동점일 경우 공연 시작일(가장 빠른 일정) 오름차순으로 2차 정렬합니다.
+	 *
+	 * @param pageable 페이징 정보 (상위 10개를 가져오기 위해 PageRequest.of(0, 10)을 사용)
+	 * @return PerformanceSummaryResponse의 페이지 객체
+	 */
+	@Query(value = """
+        SELECT new wisoft.nextframe.schedulereservationticketing.dto.performance.performancelist.response.PerformanceSummaryResponse(
+            p.id,
+            p.name,
+            p.imageUrl,
+            p.type,
+            p.genre,
+            st.name,
+            MIN(CAST(sc.performanceDatetime AS date)),
+            MAX(CAST(sc.performanceDatetime AS date)),
+            p.adultOnly
+        )
+        FROM Schedule sc
+        JOIN sc.performance p
+        JOIN sc.stadium st
+        JOIN PerformanceStatistic ps ON ps.performance = p
+        GROUP BY p.id, p.name, p.imageUrl, p.type, p.genre, st.name, p.adultOnly, ps.hit
+        HAVING MAX(sc.performanceDatetime) >= CURRENT_TIMESTAMP
+        ORDER BY ps.hit DESC, MIN(sc.performanceDatetime) ASC
+    """)
+	Page<PerformanceSummaryResponse> findTop10Performances(Pageable pageable);
 }

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceStatisticRepository.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceStatisticRepository.java
@@ -1,0 +1,10 @@
+package wisoft.nextframe.schedulereservationticketing.repository.performance;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import wisoft.nextframe.schedulereservationticketing.entity.performance.PerformanceStatistic;
+
+public interface PerformanceStatisticRepository extends JpaRepository<PerformanceStatistic, UUID> {
+}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/performance/PerformanceService.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/performance/PerformanceService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +16,7 @@ import wisoft.nextframe.schedulereservationticketing.dto.performance.performance
 import wisoft.nextframe.schedulereservationticketing.dto.performance.performancedetail.response.SeatSectionPriceResponse;
 import wisoft.nextframe.schedulereservationticketing.dto.performance.performancelist.response.PerformanceListResponse;
 import wisoft.nextframe.schedulereservationticketing.dto.performance.performancelist.response.PerformanceSummaryResponse;
+import wisoft.nextframe.schedulereservationticketing.dto.performance.performancelist.response.Top10PerformanceListResponse;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.Performance;
 import wisoft.nextframe.schedulereservationticketing.entity.schedule.Schedule;
 import wisoft.nextframe.schedulereservationticketing.repository.performance.PerformancePricingRepository;
@@ -70,5 +72,20 @@ public class PerformanceService {
 
 		// 2. Page 객체를 사용하여 최종 응답 DTO를 조립합니다.
 		return PerformanceListResponse.from(performancePage);
+	}
+
+	public Top10PerformanceListResponse getTop10Performances() {
+		log.debug("인기 공연 TOP 10 목록 조회 시작.");
+
+		// 1. 상위 10개만 조회하기 위한 Pageable 객체를 생성합니다.
+		Pageable topTenPageable = PageRequest.of(0, 10);
+
+		// 2. Repository를 호출하여 JPQL로 정의된 인기 공연 목록을 조회합니다.
+		//    (결과는 PerformanceSummaryResponse DTO 리스트로 바로 매핑됩니다.)
+		List<PerformanceSummaryResponse> top10List = performanceRepository.findTop10Performances(topTenPageable).getContent();
+		log.debug("인기 공연 목록 조회 완료. 조회된 공연 수: {}", top10List.size());
+
+		// 3. 조회된 DTO 목록을 최종 응답 DTO(Top10PerformanceListResponse)로 감싸 반환합니다.
+		return new Top10PerformanceListResponse(top10List);
 	}
 }

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryTest.java
@@ -2,9 +2,7 @@ package wisoft.nextframe.schedulereservationticketing.repository.performance;
 
 import static org.assertj.core.api.Assertions.*;
 
-import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.Optional;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -22,7 +20,9 @@ import wisoft.nextframe.schedulereservationticketing.config.AbstractIntegrationT
 import wisoft.nextframe.schedulereservationticketing.dto.performance.performancelist.response.PerformanceSummaryResponse;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.Performance;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.PerformanceGenre;
+import wisoft.nextframe.schedulereservationticketing.entity.performance.PerformanceStatistic;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.PerformanceType;
+import wisoft.nextframe.schedulereservationticketing.entity.schedule.Schedule;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.Stadium;
 import wisoft.nextframe.schedulereservationticketing.repository.schedule.ScheduleRepository;
 import wisoft.nextframe.schedulereservationticketing.repository.stadium.StadiumRepository;
@@ -35,6 +35,8 @@ class PerformanceRepositoryTest extends AbstractIntegrationTest {
 	private ScheduleRepository scheduleRepository;
 	@Autowired
 	private StadiumRepository stadiumRepository;
+	@Autowired
+	private PerformanceStatisticRepository performanceStatisticRepository;
 
 	private Stadium stadium;
 	private Pageable pageable;
@@ -43,41 +45,6 @@ class PerformanceRepositoryTest extends AbstractIntegrationTest {
 	void setUp() {
 		stadium = stadiumRepository.save(new StadiumBuilder().build());
 		pageable = PageRequest.of(0, 32);
-	}
-
-	@Test
-	@DisplayName("성공: 새로운 공연을 저장하고 ID로 조회하면 성공한다.")
-	void saveAndFindById_Success() {
-		// given
-		UUID performanceId = UUID.randomUUID();
-		Duration runningTime = Duration.ofMinutes(150);
-		Performance newPerformance = Performance.builder()
-			.id(performanceId)
-			.name("오페라의 유령")
-			.type(PerformanceType.CLASSIC)
-			.genre(PerformanceGenre.MUSICAL)
-			.adultOnly(false)
-			.runningTime(runningTime)
-			.imageUrl("http://example.com/phantom_of_the_opera.jpg")
-			.description("파리 오페라 하우스를 배경으로 한 미스터리 로맨스")
-			.build();
-
-		// when
-		performanceRepository.save(newPerformance);
-		final Optional<Performance> foundPerformanceOptional = performanceRepository.findById(performanceId);
-
-		// then
-		assertThat(foundPerformanceOptional).isPresent();
-
-		final Performance foundPerformance = foundPerformanceOptional.get();
-		assertThat(foundPerformance.getId()).isEqualTo(performanceId);
-		assertThat(foundPerformance.getName()).isEqualTo("오페라의 유령");
-		assertThat(foundPerformance.getType()).isEqualTo(PerformanceType.CLASSIC);
-		assertThat(foundPerformance.getGenre()).isEqualTo(PerformanceGenre.MUSICAL);
-		assertThat(foundPerformance.getAdultOnly()).isFalse();
-		assertThat(foundPerformance.getRunningTime()).isEqualTo(runningTime);
-		assertThat(foundPerformance.getImageUrl()).isEqualTo("http://example.com/phantom_of_the_opera.jpg");
-		assertThat(foundPerformance.getDescription()).isEqualTo("파리 오페라 하우스를 배경으로 한 미스터리 로맨스");
 	}
 
 	@Test
@@ -169,5 +136,101 @@ class PerformanceRepositoryTest extends AbstractIntegrationTest {
 			.anyMatch(dto -> dto.getId().equals(closedPerf.getId()));
 
 		assertThat(found).isFalse();
+	}
+
+	@Test
+	@DisplayName("성공: 인기 공연 10개를 조회수와 시작일 순으로 정확히 조회한다")
+	void findTop10Performances_Success() {
+		// given
+		final LocalDateTime now = LocalDateTime.now();
+		// 테스트 데이터 생성 (조회수, 시작일, 종료일)
+		// 1~10위 데이터
+		createPerformance("1위 공연", 1000, now.plusDays(10), now.plusDays(20));
+		createPerformance("2위 공연", 900, now.plusDays(10), now.plusDays(20));
+		createPerformance("3위 공연", 800, now.plusDays(10), now.plusDays(20));
+		// --- 동점자 데이터 (4, 5위) ---
+		// 4위: 조회수는 같지만, 시작일이 더 빠름
+		createPerformance("4위 공연 (동점-빠름)", 700, now.plusDays(5), now.plusDays(15));
+		// 5위: 조회수는 같지만, 시작일이 더 늦음
+		createPerformance("5위 공연 (동점-늦음)", 700, now.plusDays(8), now.plusDays(18));
+		// ----------------------------
+		createPerformance("6위 공연", 600, now.plusDays(10), now.plusDays(20));
+		createPerformance("7위 공연", 500, now.plusDays(10), now.plusDays(20));
+		createPerformance("8위 공연", 400, now.plusDays(10), now.plusDays(20));
+		createPerformance("9위 공연", 300, now.plusDays(10), now.plusDays(20));
+		createPerformance("10위 공연", 200, now.plusDays(10), now.plusDays(20));
+
+		// --- 조회에서 제외되어야 할 데이터 ---
+		// 11순위 (TOP 10에 포함되지 않음)
+		createPerformance("11위 공연(미포함)", 100, now.plusDays(10), now.plusDays(20));
+		// 조회수는 가장 높지만, 이미 종료된 공연 (미포함)
+		createPerformance("종료된 인기공연(미포함)", 9999, now.minusDays(20), now.minusDays(10));
+
+		Pageable topTenPageable = PageRequest.of(0, 10);
+
+		// when
+		final Page<PerformanceSummaryResponse> resultPage = performanceRepository.findTop10Performances(topTenPageable);
+
+		// then
+		// 1. 결과는 정확히 10개여야 한다.
+		assertThat(resultPage.getContent()).hasSize(10);
+
+		// 2. 제외되어야 할 공연들이 없는지 확인한다.
+		assertThat(resultPage.getContent())
+			.extracting(PerformanceSummaryResponse::getName)
+			.doesNotContain("11위 공연(미포함)", "종료된 인기공연(미포함)");
+
+		// 3. 정렬 순서가 정확한지 확인한다. (조회수 DESC, 시작일 ASC)
+		assertThat(resultPage.getContent())
+			.extracting(PerformanceSummaryResponse::getName)
+			.containsExactly(
+				"1위 공연",
+				"2위 공연",
+				"3위 공연",
+				"4위 공연 (동점-빠름)", // 동점자 중 시작일이 빠른 공연
+				"5위 공연 (동점-늦음)", // 동점자 중 시작일이 늦은 공연
+				"6위 공연",
+				"7위 공연",
+				"8위 공연",
+				"9위 공연",
+				"10위 공연"
+			);
+	}
+
+	private void createPerformance(String name, int hit, LocalDateTime startDate, LocalDateTime endDate) {
+		Performance performance = performanceRepository.save(
+			Performance.builder()
+				.id(UUID.randomUUID())
+				.name(name)
+				.type(PerformanceType.CLASSIC)
+				.genre(PerformanceGenre.PLAY)
+				.adultOnly(false)
+				.build()
+		);
+		performanceStatisticRepository.save(
+			PerformanceStatistic.builder()
+				.performance(performance) // 연관관계 설정
+				.hit(hit)
+				.build()
+		);
+		scheduleRepository.save(
+			Schedule.builder()
+				.id(UUID.randomUUID())
+				.performance(performance)
+				.stadium(stadium)
+				.performanceDatetime(startDate)
+				.build()
+		);
+		// endDate가 startDate와 다른 경우, 마지막 일정을 하나 더 추가
+		if (!startDate.isEqual(endDate)) {
+			scheduleRepository.save(
+				Schedule.builder()
+					.id(UUID.randomUUID())
+					.performance(performance)
+					.stadium(stadium)
+					.performanceDatetime(endDate)
+					.build()
+			);
+		}
 	}
 }


### PR DESCRIPTION
## 🛠️ 설명 (Description)

사용자에게 조회수를 기준으로 인기 공연 목록을 조회하는 API를 개발했습니다.

이번 작업을 통해 공연 통계(PerformanceStatistics) 엔티티를 추가하고, Controller, Service, Repository를 포함한 API의 전체 스택을 구현하여 인기 공연 목록을 반환하는 엔드포인트(GET /performances/top10)를 추가했습니다. 또한 복잡한 정렬 기준을 처리하기 위해 PerformanceRepository에 JPQL을 이용한 전용 조회 메서드를 추가하여 데이터베이스 조회 성능을 최적화했습니다.

## 📄 설계 문서 (Design Document)

## ✅ 테스트 계획 (Test Plan)

- Unit Test: PerformanceRepository에 추가된 인기 공연 조회 메서드가 정확한 정렬 순서로 데이터를 반환하는지 단위 테스트를 통해 검증했습니다.
- API E2E Test: Postman을 사용하여 실제 API 엔드포인트(GET /performances/top10)에 요청을 보내고, 예상된 데이터와 상태 코드가 응답되는지 End-to-End 테스트를 완료했습니다.

## 📝 변경 사항 요약 (Summary)

- 인기 공연 목록 조회 API 엔드포인트 추가 (PerformanceController)
- 공연 통계 관리 비즈니스 로직 구현 (PerformanceService)
- 인기 공연 조회를 위한 전용 Repository 메서드 추가 (PerformanceRepository) 및 단위 테스트 코드 작성
- PerformanceStatistics 엔티티 추가 (1:1 식별 관계 매핑)

## 🔗 관련 이슈 (Related Issues)

- Closed #109 

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

이번 작업의 핵심은 PerformanceRepository에 추가된 JPQL 쿼리입니다.

조회수(hit)와 평균 별점(averageStar)을 기준으로 내림차순 정렬하는 로직이 포함되어 있습니다. 혹시 더 효율적인 쿼리나 개선할 부분이 있는지 중점적으로 리뷰해주시면 감사하겠습니다.

## ➕ 추가 정보 (Additional Information)
