### PR TITLE
fix(security): CORS 설정 통합 및 Swagger 접근 허용 개선

### DIFF
--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/CorsProperties.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/CorsProperties.java
@@ -1,0 +1,7 @@
+package wisoft.nextframe.schedulereservationticketing.config;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "cors")
+public record CorsProperties(List<String> allowedOrigins) {}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/SecurityConfig.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/SecurityConfig.java
@@ -1,14 +1,22 @@
 package wisoft.nextframe.schedulereservationticketing.config;
 
+import static org.springframework.security.config.Customizer.*;
+
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import lombok.RequiredArgsConstructor;
 import wisoft.nextframe.schedulereservationticketing.common.filter.JwtAuthenticationFilter;
@@ -19,6 +27,7 @@ import wisoft.nextframe.schedulereservationticketing.common.filter.JwtAuthentica
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+	private final CorsProperties corsProperties;
 	private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
 	@Bean
@@ -26,6 +35,7 @@ public class SecurityConfig {
 		http
 			// CSRF 보호 기능을 비활성화합니다.
 			.csrf(AbstractHttpConfigurer::disable)
+			.cors(withDefaults())
 
 			// 세션을 사용하지 않으므로, STATELESS(상태 비저장)으로 설정합니다(세션 대신 토큰을 사용함).
 			.sessionManagement(session ->
@@ -37,7 +47,12 @@ public class SecurityConfig {
 				.requestMatchers("/",
 					"/api/v1/performances/**",
 					"api/v1/tickets",
-					"/api/v1/auth/**").permitAll()
+					"/api/v1/auth/**",
+					"/v3/api-docs/**",
+					"/swagger-ui/**",
+					"/swagger-ui.html").permitAll()
+				// CORS preflight 요청 허용
+				.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
 				// 그 외의 모든 요청은 인증된 사용자만 접근할 수 있도록 설정합니다.
 				.anyRequest().authenticated()
 			);
@@ -45,5 +60,22 @@ public class SecurityConfig {
 		http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
+	}
+
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		var configuration = new CorsConfiguration();
+		List<String> origins =
+			corsProperties.allowedOrigins() == null ? List.of() : corsProperties.allowedOrigins();
+
+		configuration.setAllowedOrigins(origins);
+		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+		configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "Accept"));
+		configuration.setAllowCredentials(true);
+		configuration.setMaxAge(3600L);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
 	}
 }


### PR DESCRIPTION
## 🛠️ 설명 (Description)

- Preflight 요청(OPTIONS) 허용으로 403 오류 해결
- Swagger 문서(`/v3/api-docs/**`, `/swagger-ui/**`) 접근 허용
- 로컬(http)과 운영(https) Origin 모두 등록하여 환경별 접근 보장
- `application.yml` 및 문서에 CORS 관련 설정 반영

## ✅ 테스트 계획 (Test Plan)

- Swagger UI 접근 (`/swagger-ui/index.html`) 정상 확인
- CORS preflight(OPTIONS) 요청 200 응답 확인
- 로컬((http://localhost:../)) 및 운영 도메인(https://...)에서 API 요청 성공 확인

## 📝 변경 사항 요약 (Summary)

- `SecurityConfig` 내 `http.cors(withDefaults())` 활성화
- `.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()` 추가
- Swagger 경로 `/v3/api-docs/**`, `/swagger-ui/**`, `/swagger-ui.html` 허용
- `application.yml` CORS 설정 변경 및 환경별 Origin 등록

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 변경 사항에 대한 문서화가 완료되었습니다.

## ➕ 추가 정보 (Additional Information)
- `SecurityConfig`와 `application.yml` 두 부분이 모두 변경됨
- 운영 환경에서는 Swagger 접근 경로를 필요 시 제한할 예정
- 프론트엔드와의 통합 테스트 시 반드시 CORS 동작을 재검증 필요
