### PR TITLE
#116 feat(security): 인증/인가 처리 및 동적 권한 검사 구현

### DIFF
--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/security/CorsProperties.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/security/CorsProperties.java
@@ -1,4 +1,4 @@
-package wisoft.nextframe.schedulereservationticketing.config;
+package wisoft.nextframe.schedulereservationticketing.config.security;
 
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/security/CustomAccessDeniedHandler.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,40 @@
+package wisoft.nextframe.schedulereservationticketing.config.security;
+
+import java.io.IOException;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import wisoft.nextframe.schedulereservationticketing.common.response.ApiErrorResponse;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response,
+		AccessDeniedException accessDeniedException) throws IOException, ServletException {
+		// 응답 내용 생성
+		final ApiErrorResponse apiErrorResponse = new ApiErrorResponse("FORBIDDEN");
+
+		// HTTP 상태 코드 설정
+		response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+		// 응답의 Content-Type과 인코딩 설정
+		response.setContentType("application/json");
+		response.setCharacterEncoding("utf-8");
+
+		// ObjectMapper를 사용해 apiErrorResponse 객체를 Json 문자열로 변환하여 응답 본문에 작성
+		final String jsonResponse = objectMapper.writeValueAsString(apiErrorResponse);
+		response.getWriter().write(jsonResponse);
+	}
+}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/security/CustomAuthenticationEntryPoint.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,39 @@
+package wisoft.nextframe.schedulereservationticketing.config.security;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import wisoft.nextframe.schedulereservationticketing.common.response.ApiErrorResponse;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException authException) throws IOException {
+		// 응답 내용 생성
+		final ApiErrorResponse apiErrorResponse = new ApiErrorResponse("UNAUTHORIZED");
+
+		// HTTP 상태 코드 설정
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+
+		// 응답의 Content-Type과 인코딩 설정
+		response.setContentType("application/json");
+		response.setCharacterEncoding("utf-8");
+
+		// ObjectMapper를 사용해 apiErrorResponse 객체를 Json 문자열로 변환하여 응답 본문에 작성
+		final String jsonResponse = objectMapper.writeValueAsString(apiErrorResponse);
+		response.getWriter().write(jsonResponse);
+	}
+}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/security/SecurityConfigForLoadTest.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/security/SecurityConfigForLoadTest.java
@@ -1,4 +1,4 @@
-package wisoft.nextframe.schedulereservationticketing.config;
+package wisoft.nextframe.schedulereservationticketing.config.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/performance/PerformanceController.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/performance/PerformanceController.java
@@ -6,25 +6,19 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
-import org.springframework.util.StringUtils;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import jakarta.persistence.EntityNotFoundException;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import wisoft.nextframe.schedulereservationticketing.common.response.ApiResponse;
-import wisoft.nextframe.schedulereservationticketing.config.jwt.JwtTokenProvider;
 import wisoft.nextframe.schedulereservationticketing.dto.performance.performancedetail.response.PerformanceDetailResponse;
 import wisoft.nextframe.schedulereservationticketing.dto.performance.performancelist.response.PerformanceListResponse;
 import wisoft.nextframe.schedulereservationticketing.dto.performance.performancelist.response.Top10PerformanceListResponse;
-import wisoft.nextframe.schedulereservationticketing.entity.user.User;
-import wisoft.nextframe.schedulereservationticketing.repository.user.UserRepository;
 import wisoft.nextframe.schedulereservationticketing.service.performance.PerformanceService;
 
 @Slf4j
@@ -34,34 +28,13 @@ import wisoft.nextframe.schedulereservationticketing.service.performance.Perform
 public class PerformanceController {
 
 	private final PerformanceService performanceService;
-	private final JwtTokenProvider jwtTokenProvider;
-	private final UserRepository userRepository;
 
+	@PreAuthorize("@dynamicAuthService.canViewPerformanceDetail(#id, authentication)")
 	@GetMapping("/{id}")
-	public ResponseEntity<ApiResponse<?>> getPerformanceDetail(@PathVariable UUID id, HttpServletRequest request) {
+	public ResponseEntity<ApiResponse<?>> getPerformanceDetail(@P("id") @PathVariable UUID id) {
 		log.info("공연 상세 조회 요청. performanceId: {}", id);
+
 		final PerformanceDetailResponse data = performanceService.getPerformanceDetail(id);
-
-		if (data.adultOnly()) {
-			log.info("성인 전용 공연. 인증 확인 시작. performanceId: {}", id);
-			final String token = resolveToken(request);
-
-			if (token == null || !jwtTokenProvider.validateToken(token)) {
-				log.warn("유효하지 않은 토큰으로 성인 공연 접근 시도. performanceId: {}", id);
-				throw new AuthenticationCredentialsNotFoundException("유효한 인증 정보가 없습니다.");
-			}
-
-			final UUID userId = jwtTokenProvider.getUserIdFromToken(token);
-			final User user = userRepository.findById(userId)
-				.orElseThrow(() -> new EntityNotFoundException("해당 사용자를 찾을 수 없습니다."));
-
-			if (!user.isAdult()) {
-				log.warn("성인 인증 실패. userId: {}, performanceId: {}", userId, id);
-				throw new AccessDeniedException("성인 인증이 필요한 공연입니다.");
-			}
-			log.info("성인 인증 성공. userId: {}", userId);
-		}
-
 		final ApiResponse<PerformanceDetailResponse> response = ApiResponse.success(data);
 		log.info("공연 상세 조회 성공. performanceId: {}", id);
 		return new ResponseEntity<>(response, HttpStatus.OK);
@@ -85,13 +58,5 @@ public class PerformanceController {
 		final ApiResponse<Top10PerformanceListResponse> response = ApiResponse.success(data);
 		log.info("인기 공연 TOP 10 조회 성공.");
 		return ResponseEntity.ok(response);
-	}
-
-	private String resolveToken(HttpServletRequest request) {
-		final String bearerToken = request.getHeader("Authorization");
-		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-			return bearerToken.substring(7);
-		}
-		return null;
 	}
 }

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepository.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepository.java
@@ -1,11 +1,13 @@
 package wisoft.nextframe.schedulereservationticketing.repository.performance;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import wisoft.nextframe.schedulereservationticketing.dto.performance.performancelist.response.PerformanceSummaryResponse;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.Performance;
@@ -82,4 +84,12 @@ public interface PerformanceRepository extends JpaRepository<Performance, UUID> 
         ORDER BY ps.hit DESC, MIN(sc.performanceDatetime) ASC
     """)
 	Page<PerformanceSummaryResponse> findTop10Performances(Pageable pageable);
+
+	/**
+	 * 공연 ID를 기반으로 성인 관람 여부(adultOnly)만 조회하는 메소드.
+	 * @param id 공연 ID
+	 * @return 성인 관람 여부 (true/false)
+	 */
+	@Query("SELECT p.adultOnly FROM Performance p WHERE p.id = :id")
+	Optional<Boolean> findAdultOnlyById(@Param("id") UUID id);
 }

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/auth/DynamicAuthService.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/auth/DynamicAuthService.java
@@ -1,0 +1,45 @@
+package wisoft.nextframe.schedulereservationticketing.service.auth;
+
+import java.util.UUID;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import wisoft.nextframe.schedulereservationticketing.entity.user.User;
+import wisoft.nextframe.schedulereservationticketing.repository.performance.PerformanceRepository;
+import wisoft.nextframe.schedulereservationticketing.repository.user.UserRepository;
+
+@Service("dynamicAuthService")
+@RequiredArgsConstructor
+public class DynamicAuthService {
+
+	private final PerformanceRepository performanceRepository;
+	private final UserRepository userRepository;
+
+	@Transactional(readOnly = true)
+	public boolean canViewPerformanceDetail(UUID performanceId, Authentication authentication) {
+		// 1. 공연이 성인 공연인지 확인
+		final boolean isAdultOnly = performanceRepository.findAdultOnlyById(performanceId)
+			.orElse(false);
+
+		// 2. 성인 전용 공연이 아니면 -> 누구나 접근 가능 (true)
+		if (!isAdultOnly) {
+			return true;
+		}
+
+		// 3. 인증 정보가 없거나, Principal이 UUID 타입이 아니면(즉, 익명 사용자) -> 접근 불가 (false)
+		if (authentication == null || !(authentication.getPrincipal() instanceof UUID)) {
+			return false;
+		}
+
+		// 4. 이제 안심하고 UUID로 캐스팅합니다.
+		final UUID userId = (UUID)authentication.getPrincipal();
+		final User user = userRepository.findById(userId)
+			.orElseThrow(() -> new EntityNotFoundException("인증 정보에 해당하는 사용자를 찾을 수 없습니다: " + userId));
+
+		return user.isAdult();
+	}
+}


### PR DESCRIPTION
## 🛠️ 설명 (Description)

Spring Security 아키텍처를 개선하여 코드의 유지보수성과 안정성을 향상시키는 작업을 진행했습니다.

이번 PR의 핵심 목표는 각 컴포넌트의 역할을 명확히 분리하는 것입니다. 기존에 컨트롤러가 과도하게 가지고 있던 인증/인가 책임을 Spring Security 계층으로 위임하고, 인증/인가 실패 시 클라이언트가 예측 가능한 일관된 에러를 받도록 시스템을 표준화했습니다.

## 📄 설계 문서 (Design Document)

## ✅ 테스트 계획 (Test Plan)

Postman을 사용하여 다음과 같은 시나리오에 대한 통합 테스트를 수행했습니다.

- 인증(401) 실패 테스트
   - 인증이 필요한 API에 토큰 없이 접근 시, 표준화된 401 에러 JSON 응답 확인
- 인가(403) 실패 테스트
   - 성인 전용 공연에 미성년자 계정 토큰으로 접근 시, 표준화된 403 에러 JSON 응답 확인
   - 성인 전용 공연에 토큰 없이 접근 시, @PreAuthorize에 의해 403 에러 JSON 응답 확인
- 정상 동작 테스트
   - 성인 전용 공연에 성인 계정 토큰으로 접근 시, 200 OK 응답 확인
   - 일반 공연에 토큰 없이 접근 시, 200 OK 응답 확인

## 📝 변경 사항 요약 (Summary)

- 일관된 에러 처리 시스템 구축: 인증(401) 실패 시 CustomAuthenticationEntryPoint, 인가(403) 실패 시 CustomAccessDeniedHandler가 동작하도록 구현하여, 모든 보안 관련 에러가 표준화된 JSON 형식으로 응답되도록 변경했습니다.
- 동적 권한 검사 로직 분리: 컨트롤러가 직접 수행하던 '성인 인증' 로직을 AuthorizationService와 @PreAuthorize를 사용하는 방식으로 리팩터링했습니다. 이로써 컨트롤러는 순수하게 API의 요청/응답 처리에만 집중하게 됩니다.
- 보안 설정 및 인프라 보완: SecurityConfig 내 permitAll 경로의 오타를 수정하고, Swagger UI 관련 모든 경로를 명시적으로 추가하여 개발 편의성을 향상시켰습니다. 또한 CORS 설정을 검토하여 보완했습니다.

## 🔗 관련 이슈 (Related Issues)

- Closed #116 

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

이번 PR의 핵심은 컨트롤러의 책임 분리입니다. PerformanceController에 있던 토큰 파싱, 유저 조회, 성인 여부 검사 로직이 모두 사라지고, @PreAuthorize 어노테이션을 통해 AuthorizationService로 책임이 위임된 부분을 중점적으로 봐주시면 좋겠습니다.

## ➕ 추가 정보 (Additional Information)
