### PR TITLE
#120 feat(performance): 공연 상세 API 별점 정보 동적 조회로 변경

### DIFF
--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/common/exception/DomainException.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/common/exception/DomainException.java
@@ -1,7 +1,6 @@
-package wisoft.nextframe.schedulereservationticketing.exception;
+package wisoft.nextframe.schedulereservationticketing.common.exception;
 
 import lombok.Getter;
-import wisoft.nextframe.schedulereservationticketing.common.exception.ErrorCode;
 
 @Getter
 public class DomainException extends RuntimeException {

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/common/exception/ErrorCode.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/common/exception/ErrorCode.java
@@ -34,10 +34,24 @@ public enum ErrorCode {
 	TOTAL_PRICE_MISMATCH(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "요청한 금액과 계산된 금액이 일치하지 않습니다."),
 	SEAT_NOT_DEFINED(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "요청한 좌석 중 일부를 찾을 수 없습니다."),
 	PERFORMANCE_SCHEDULE_MISMATCH(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "공연과 공연 일정 정보가 일치하지 않습니다."),
+	RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOT_FOUND", "해당 예약 정보를 찾을 수 없습니다."),
 
-	// Review(추가 예정)
+	// Review
 	REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "NOT_FOUND", "해당 리뷰을 찾을 수 없습니다."),
-	REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "CONFLICT", "이미 리뷰를 작성했습니다.");
+	REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "CONFLICT", "이미 리뷰를 작성했습니다."),
+
+	// Ticketing
+	TICKET_ALREADY_ISSUED(HttpStatus.CONFLICT, "CONFLICT", "이미 발급된 티켓입니다."),
+	TICKET_NOT_FOUND(HttpStatus.NOT_FOUND, "NOT_FOUND", "해당 티켓을 찾을 수 없습니다."),
+	PAYMENT_NOT_COMPLETED(HttpStatus.CONFLICT, "CONFLICT", "결제 완료된 상태가 아닐 경우, 티켓을 발급할 수 없습니다."),
+
+	// OAuth
+	FAILED_TO_RECEIVE_KAKAO_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR",
+		"카카오 서버로부터 토큰 응답을 받지 못했습니다."),
+	MISSING_KAKAO_ACCESS_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR",
+		"카카오 토큰 응답에 access token이 없습니다."),
+	FAILED_TO_GET_KAKAO_USER_INFO(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR",
+		"카카오 사용자 정보를 받아오는데 실패했습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/common/exception/GlobalExceptionHandler.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/common/exception/GlobalExceptionHandler.java
@@ -10,7 +10,6 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import wisoft.nextframe.schedulereservationticketing.common.response.ApiResponse;
-import wisoft.nextframe.schedulereservationticketing.exception.DomainException;
 
 @Slf4j
 @RestControllerAdvice
@@ -37,7 +36,7 @@ public class GlobalExceptionHandler {
 	// 도메인 관련 예외를 처리
 	@ExceptionHandler(DomainException.class)
 	protected ResponseEntity<ApiResponse<?>> handleDomainException(DomainException ex) {
-		log.warn("BusinessException: {}", ex.getMessage());
+		log.warn("DomainException: {}", ex.getMessage());
 		final ErrorCode errorCode = ex.getErrorCode();
 		final ApiResponse<?> response = ApiResponse.error(errorCode);
 		return new ResponseEntity<>(response, errorCode.getHttpStatus());

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/jwt/JwtAuthenticationFilter.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/jwt/JwtAuthenticationFilter.java
@@ -22,7 +22,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import wisoft.nextframe.schedulereservationticketing.common.exception.ErrorCode;
-import wisoft.nextframe.schedulereservationticketing.exception.DomainException;
+import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
 
 @Slf4j
 @Component

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/security/CustomAccessDeniedHandler.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/security/CustomAccessDeniedHandler.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +22,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 
 	@Override
 	public void handle(HttpServletRequest request, HttpServletResponse response,
-		AccessDeniedException accessDeniedException) throws IOException, ServletException {
+		AccessDeniedException accessDeniedException) throws IOException {
 		// 응답 내용 생성
 		final ApiResponse<?> apiErrorResponse = ApiResponse.error(ErrorCode.ACCESS_DENIED);
 

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/dto/performance/performancedetail/response/PerformanceDetailResponse.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/dto/performance/performancedetail/response/PerformanceDetailResponse.java
@@ -1,33 +1,45 @@
 package wisoft.nextframe.schedulereservationticketing.dto.performance.performancedetail.response;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
-import jakarta.persistence.EntityNotFoundException;
 import lombok.Builder;
+import wisoft.nextframe.schedulereservationticketing.common.exception.ErrorCode;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.Performance;
+import wisoft.nextframe.schedulereservationticketing.entity.performance.PerformanceStatistic;
 import wisoft.nextframe.schedulereservationticketing.entity.schedule.Schedule;
+import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
 
 @Builder
-public record PerformanceDetailResponse(UUID id, String imageUrl, String name, String type, String genre,
-																				Double averageStar, Integer runningTime, String description, Boolean adultOnly,
-																				LocalDateTime ticketOpenTime, LocalDateTime ticketCloseTime,
-																				StadiumResponse stadium, List<PerformanceScheduleResponse> performanceSchedules,
-																				List<SeatSectionPriceResponse> seatSectionPrices) {
-
-	// todo: 공연 별점 기능 개발 후 변경할 예정
-	public static final Double DEFAULT_AVERAGE_STAR = 4.8;
+public record PerformanceDetailResponse(
+	UUID id,
+	String imageUrl,
+	String name,
+	String type,
+	String genre,
+	BigDecimal averageStar,
+	Integer runningTime,
+	String description,
+	Boolean adultOnly,
+	LocalDateTime ticketOpenTime,
+	LocalDateTime ticketCloseTime,
+	StadiumResponse stadium,
+	List<PerformanceScheduleResponse> performanceSchedules,
+	List<SeatSectionPriceResponse> seatSectionPrices
+) {
 
 	public static PerformanceDetailResponse from(
 		Performance performance,
 		List<Schedule> schedules,
-		List<SeatSectionPriceResponse> seatSectionPrices
+		List<SeatSectionPriceResponse> seatSectionPrices,
+		PerformanceStatistic performanceStatistic
 	) {
 		final StadiumResponse stadiumResponse = schedules.stream()
 			.findFirst()
 			.map(schedule -> StadiumResponse.from(schedule.getStadium()))
-			.orElseThrow(() -> new EntityNotFoundException("해당 공연장을 찾을 수 없습니다."));
+			.orElseThrow(() -> new DomainException(ErrorCode.STADIUM_NOT_FOUND));
 
 		final List<PerformanceScheduleResponse> performanceScheduleResponses = schedules.stream()
 			.map(PerformanceScheduleResponse::from)
@@ -42,8 +54,8 @@ public record PerformanceDetailResponse(UUID id, String imageUrl, String name, S
 			.name(performance.getName())
 			.type(performance.getType().name())
 			.genre(performance.getGenre().name())
-			.averageStar(DEFAULT_AVERAGE_STAR)
-			.runningTime((int) performance.getRunningTime().toMinutes())
+			.averageStar(performanceStatistic.getAverageStar())
+			.runningTime((int)performance.getRunningTime().toMinutes())
 			.description(performance.getDescription())
 			.adultOnly(performance.getAdultOnly())
 			.ticketOpenTime(ticketOpenTime)

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/performance/Performance.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/performance/Performance.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 import wisoft.nextframe.schedulereservationticketing.common.exception.ErrorCode;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.typeconverter.DurationMinutesConverter;
 import wisoft.nextframe.schedulereservationticketing.entity.user.User;
-import wisoft.nextframe.schedulereservationticketing.exception.DomainException;
+import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
 
 @Getter
 @Builder

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/schedule/Schedule.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/schedule/Schedule.java
@@ -22,7 +22,7 @@ import wisoft.nextframe.schedulereservationticketing.entity.performance.Performa
 import wisoft.nextframe.schedulereservationticketing.entity.seat.SeatState;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.SeatDefinition;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.Stadium;
-import wisoft.nextframe.schedulereservationticketing.exception.DomainException;
+import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
 import wisoft.nextframe.schedulereservationticketing.repository.seat.SeatStateRepository;
 
 @Getter

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/exception/reservation/ReservationException.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/exception/reservation/ReservationException.java
@@ -1,7 +1,0 @@
-package wisoft.nextframe.schedulereservationticketing.exception.reservation;
-
-public class ReservationException extends RuntimeException {
-	public ReservationException(String message) {
-		super(message);
-	}
-}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/exception/review/DuplicateReviewException.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/exception/review/DuplicateReviewException.java
@@ -1,7 +1,0 @@
-package wisoft.nextframe.schedulereservationticketing.exception.review;
-
-public class DuplicateReviewException extends ReviewException {
-	public DuplicateReviewException() {
-		super("이미 해당 공연에 대한 리뷰를 작성했습니다.");
-	}
-}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/exception/review/NoReservationFoundException.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/exception/review/NoReservationFoundException.java
@@ -1,7 +1,0 @@
-package wisoft.nextframe.schedulereservationticketing.exception.review;
-
-public class NoReservationFoundException extends ReviewException {
-    public NoReservationFoundException() {
-        super("리뷰를 작성하려면 먼저 공연을 예매해야 합니다.");
-    }
-}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/exception/review/ReviewException.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/exception/review/ReviewException.java
@@ -1,7 +1,0 @@
-package wisoft.nextframe.schedulereservationticketing.exception.review;
-
-public class ReviewException extends RuntimeException {
-	public ReviewException(String message) {
-		super(message);
-	}
-}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/exception/review/ReviewPermissionDeniedException.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/exception/review/ReviewPermissionDeniedException.java
@@ -1,7 +1,0 @@
-package wisoft.nextframe.schedulereservationticketing.exception.review;
-
-public class ReviewPermissionDeniedException extends RuntimeException {
-	public ReviewPermissionDeniedException() {
-		super("리뷰를 수정할 권한이 없습니다.");
-	}
-}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/exception/ticketing/AlreadyIssuedException.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/exception/ticketing/AlreadyIssuedException.java
@@ -1,9 +1,0 @@
-package wisoft.nextframe.schedulereservationticketing.exception.ticketing;
-
-import java.util.UUID;
-
-public class AlreadyIssuedException extends RuntimeException {
-	public AlreadyIssuedException(UUID reservationId) {
-		super("이미 발급된 티켓입니다. 예약 ID: " + reservationId);
-	}
-}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/exception/ticketing/CannotIssueTicketWithoutPaymentException.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/exception/ticketing/CannotIssueTicketWithoutPaymentException.java
@@ -1,7 +1,0 @@
-package wisoft.nextframe.schedulereservationticketing.exception.ticketing;
-
-public class CannotIssueTicketWithoutPaymentException extends RuntimeException {
-	public CannotIssueTicketWithoutPaymentException() {
-		super("결제 완료된 상태가 아닐 경우, 티켓을 발급할 수 없습니다.");
-	}
-}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/auth/AuthService.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/auth/AuthService.java
@@ -13,7 +13,7 @@ import wisoft.nextframe.schedulereservationticketing.config.jwt.JwtTokenProvider
 import wisoft.nextframe.schedulereservationticketing.dto.auth.tokenrefresh.TokenRefreshResponse;
 import wisoft.nextframe.schedulereservationticketing.entity.user.RefreshToken;
 import wisoft.nextframe.schedulereservationticketing.entity.user.User;
-import wisoft.nextframe.schedulereservationticketing.exception.DomainException;
+import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
 import wisoft.nextframe.schedulereservationticketing.repository.user.RefreshTokenRepository;
 import wisoft.nextframe.schedulereservationticketing.repository.user.UserRepository;
 

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/auth/DynamicAuthService.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/auth/DynamicAuthService.java
@@ -6,8 +6,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
+import wisoft.nextframe.schedulereservationticketing.common.exception.ErrorCode;
 import wisoft.nextframe.schedulereservationticketing.entity.user.User;
 import wisoft.nextframe.schedulereservationticketing.repository.performance.PerformanceRepository;
 import wisoft.nextframe.schedulereservationticketing.repository.user.UserRepository;
@@ -31,14 +32,13 @@ public class DynamicAuthService {
 		}
 
 		// 3. 인증 정보가 없거나, Principal이 UUID 타입이 아니면(즉, 익명 사용자) -> 접근 불가 (false)
-		if (authentication == null || !(authentication.getPrincipal() instanceof UUID)) {
+		if (authentication == null || !(authentication.getPrincipal() instanceof UUID userId)) {
 			return false;
 		}
 
-		// 4. 이제 안심하고 UUID로 캐스팅합니다.
-		final UUID userId = (UUID)authentication.getPrincipal();
+		// 4. UUID로 캐스팅합니다.
 		final User user = userRepository.findById(userId)
-			.orElseThrow(() -> new EntityNotFoundException("인증 정보에 해당하는 사용자를 찾을 수 없습니다: " + userId));
+			.orElseThrow(() -> new DomainException(ErrorCode.USER_NOT_FOUND));
 
 		return user.isAdult();
 	}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/auth/KakaoApiClient.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/auth/KakaoApiClient.java
@@ -10,6 +10,8 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 
 import lombok.RequiredArgsConstructor;
+import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
+import wisoft.nextframe.schedulereservationticketing.common.exception.ErrorCode;
 import wisoft.nextframe.schedulereservationticketing.dto.auth.KakaoTokenResponse;
 import wisoft.nextframe.schedulereservationticketing.dto.auth.KakaoUserInfoResponse;
 
@@ -47,11 +49,11 @@ public class KakaoApiClient {
 			.body(KakaoTokenResponse.class);
 
 		if (response == null) {
-			throw new RuntimeException("카카오 서버로부터 토큰 응답을 받지 못했습니다. (response is null)");
+			throw new DomainException(ErrorCode.FAILED_TO_RECEIVE_KAKAO_TOKEN);
 		}
 		String accessToken = response.getAccessToken();
 		if (accessToken == null) {
-			throw new RuntimeException("카카오 토큰 응답에는 access token이 없습니다. (access token is null)");
+			throw new DomainException(ErrorCode.MISSING_KAKAO_ACCESS_TOKEN);
 		}
 		return accessToken;
 	}
@@ -71,6 +73,6 @@ public class KakaoApiClient {
 			.body(KakaoUserInfoResponse.class);
 
 		return Optional.ofNullable(response)
-			.orElseThrow(() -> new RuntimeException("카카오 사용자 정보를 받아오는데 실패했습니다."));
+			.orElseThrow(() -> new DomainException(ErrorCode.FAILED_TO_GET_KAKAO_USER_INFO));
 	}
 }

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationDataProvider.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationDataProvider.java
@@ -12,7 +12,7 @@ import wisoft.nextframe.schedulereservationticketing.entity.performance.Performa
 import wisoft.nextframe.schedulereservationticketing.entity.schedule.Schedule;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.SeatDefinition;
 import wisoft.nextframe.schedulereservationticketing.entity.user.User;
-import wisoft.nextframe.schedulereservationticketing.exception.DomainException;
+import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
 import wisoft.nextframe.schedulereservationticketing.repository.schedule.ScheduleRepository;
 import wisoft.nextframe.schedulereservationticketing.repository.stadium.SeatDefinitionRepository;
 import wisoft.nextframe.schedulereservationticketing.repository.user.UserRepository;

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationService.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationService.java
@@ -17,7 +17,7 @@ import wisoft.nextframe.schedulereservationticketing.entity.reservation.Reservat
 import wisoft.nextframe.schedulereservationticketing.entity.schedule.Schedule;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.SeatDefinition;
 import wisoft.nextframe.schedulereservationticketing.entity.user.User;
-import wisoft.nextframe.schedulereservationticketing.exception.DomainException;
+import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
 import wisoft.nextframe.schedulereservationticketing.repository.reservation.ReservationRepository;
 import wisoft.nextframe.schedulereservationticketing.repository.seat.SeatStateRepository;
 

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/review/ReviewService.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/review/ReviewService.java
@@ -22,7 +22,7 @@ import wisoft.nextframe.schedulereservationticketing.entity.performance.Performa
 import wisoft.nextframe.schedulereservationticketing.entity.review.Review;
 import wisoft.nextframe.schedulereservationticketing.entity.review.ReviewLike;
 import wisoft.nextframe.schedulereservationticketing.entity.user.User;
-import wisoft.nextframe.schedulereservationticketing.exception.DomainException;
+import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
 import wisoft.nextframe.schedulereservationticketing.repository.performance.PerformanceRepository;
 import wisoft.nextframe.schedulereservationticketing.repository.reservation.ReservationRepository;
 import wisoft.nextframe.schedulereservationticketing.repository.review.ReviewLikeRepository;

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/seat/SeatDefinitionService.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/seat/SeatDefinitionService.java
@@ -12,7 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import wisoft.nextframe.schedulereservationticketing.common.exception.ErrorCode;
 import wisoft.nextframe.schedulereservationticketing.dto.seat.seatdefinition.SeatDefinitionListResponse;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.SeatDefinition;
-import wisoft.nextframe.schedulereservationticketing.exception.DomainException;
+import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
 import wisoft.nextframe.schedulereservationticketing.repository.stadium.SeatDefinitionRepository;
 import wisoft.nextframe.schedulereservationticketing.repository.stadium.StadiumRepository;
 

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/service/performance/PerformanceServiceTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/service/performance/PerformanceServiceTest.java
@@ -3,8 +3,10 @@ package wisoft.nextframe.schedulereservationticketing.service.performance;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.math.BigDecimal;
 import java.sql.Date;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -28,12 +30,14 @@ import wisoft.nextframe.schedulereservationticketing.dto.performance.performance
 import wisoft.nextframe.schedulereservationticketing.dto.performance.performancelist.response.PerformanceSummaryResponse;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.Performance;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.PerformanceGenre;
+import wisoft.nextframe.schedulereservationticketing.entity.performance.PerformanceStatistic;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.PerformanceType;
 import wisoft.nextframe.schedulereservationticketing.entity.schedule.Schedule;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.Stadium;
-import wisoft.nextframe.schedulereservationticketing.exception.DomainException;
+import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
 import wisoft.nextframe.schedulereservationticketing.repository.performance.PerformancePricingRepository;
 import wisoft.nextframe.schedulereservationticketing.repository.performance.PerformanceRepository;
+import wisoft.nextframe.schedulereservationticketing.repository.performance.PerformanceStatisticRepository;
 import wisoft.nextframe.schedulereservationticketing.repository.schedule.ScheduleRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -47,6 +51,8 @@ class PerformanceServiceTest {
 	private ScheduleRepository scheduleRepository;
 	@Mock
 	private PerformancePricingRepository performancePricingRepository;
+	@Mock
+	private PerformanceStatisticRepository performanceStatisticRepository;
 
 	@Test
 	@DisplayName("성공: 공연 상세 조회 성공 테스트")
@@ -59,6 +65,13 @@ class PerformanceServiceTest {
 		final Performance performance = new PerformanceBuilder()
 			.withId(performanceId)
 			.withName("오페라의 유령")
+			.build();
+
+		final PerformanceStatistic performanceStatistic = PerformanceStatistic.builder()
+			.performanceId(performanceId)
+			.hit(3000)
+			.averageStar(BigDecimal.valueOf(4.5))
+			.updatedAt(LocalDateTime.now())
 			.build();
 
 		final Stadium stadium = new StadiumBuilder()
@@ -79,12 +92,15 @@ class PerformanceServiceTest {
 				.price(150000)
 				.build()
 		);
+
 		// 3. Mock Repository 설정
 		given(performanceRepository.findById(performanceId)).willReturn(Optional.of(performance));
 		given(scheduleRepository.findByPerformanceId(performanceId)).willReturn(schedules);
 		// 'findCommonPricingByPerformanceAndStadium' 메소드를 Mocking
 		given(performancePricingRepository.findSeatSectionPrices(performanceId, stadiumId))
 			.willReturn(seatPrices);
+		given(performanceStatisticRepository.findById(performanceId))
+			.willReturn(Optional.ofNullable(performanceStatistic));
 
 		// when
 		final PerformanceDetailResponse response = performanceService.getPerformanceDetail(performanceId);
@@ -93,10 +109,12 @@ class PerformanceServiceTest {
 		assertThat(response).isNotNull();
 		assertThat(response.id()).isEqualTo(performanceId);
 		assertThat(response.name()).isEqualTo("오페라의 유령");
+		assertThat(response.averageStar()).isEqualTo(BigDecimal.valueOf(4.5));
 		assertThat(response.performanceSchedules()).hasSize(1);
 		assertThat(response.seatSectionPrices()).hasSize(1);
 		assertThat(response.seatSectionPrices().getFirst().section()).isEqualTo("A");
 		assertThat(response.seatSectionPrices().getFirst().price()).isEqualTo(150000);
+
 	}
 
 	@Test

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/service/review/ReviewServiceTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/service/review/ReviewServiceTest.java
@@ -22,7 +22,7 @@ import wisoft.nextframe.schedulereservationticketing.dto.review.ReviewCreateResp
 import wisoft.nextframe.schedulereservationticketing.entity.performance.Performance;
 import wisoft.nextframe.schedulereservationticketing.entity.review.Review;
 import wisoft.nextframe.schedulereservationticketing.entity.user.User;
-import wisoft.nextframe.schedulereservationticketing.exception.DomainException;
+import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
 import wisoft.nextframe.schedulereservationticketing.repository.performance.PerformanceRepository;
 import wisoft.nextframe.schedulereservationticketing.repository.reservation.ReservationRepository;
 import wisoft.nextframe.schedulereservationticketing.repository.review.ReviewRepository;


### PR DESCRIPTION
## 🛠️ 설명 (Description)

공연 상세 정보 조회 API(`GET /api/v1/performances/{id}`)가 항상 고정된 별점 값을 반환하던 문제를 해결했습니다.

이제 `PerformanceStatistic` 엔티티에서 해당 공연의 실제 평균 별점(`averageStar`)을 동적으로 조회하여 반환하도록 로직을 수정했습니다. 이를 통해 사용자에게 정확한 정보를 제공할 수 있습니다.

추가로, 기능 구현 과정에서 발견된 일부 예외들을 저희 프로젝트의 커스텀 예외인 DomainException으로 통일하여 예외 처리의 일관성을 높이는 리팩토링을 함께 진행했습니다.

## 📄 설계 문서 (Design Document)

## ✅ 테스트 계획 (Test Plan)

- 통합 테스트 (Integration Test)
   - PerformanceControllerTest: 실제 API 엔드포인트를 호출하여 테스트를 진행했습니다.
   - 테스트 DB에 특정 Performance와 PerformanceStatistic 데이터를 저장합니다.
   - 해당 공연의 상세 조회 API를 호출했을 때, 응답 DTO에 PerformanceStatistic의 averageStar 값이 정확히 포함되는지 검증합니다.

## 📝 변경 사항 요약 (Summary)

- PerformanceService: PerformanceStatisticRepository를 주입받아 공연 통계 정보를 조회하는 로직을 추가했습니다.
- PerformanceDetailResponse: 조회된 평균 별점 정보를 클라이언트에 전달하기 위해 averageStar 필드를 추가했습니다.
- 예외 처리: DomainException이 적용되지 않았던 일부 로직에 커스텀 예외를 적용하여 일관성을 확보했습니다.

## 🔗 관련 이슈 (Related Issues)

- Closed #120 

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)