### PR TITLE
#124 feat(loadtest): 부하 테스트 전용 API 구현

### DIFF
--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/common/aop/LoggingAspect.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/common/aop/LoggingAspect.java
@@ -1,7 +1,5 @@
 package wisoft.nextframe.schedulereservationticketing.common.aop;
 
-import java.util.Arrays;
-
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -33,7 +31,7 @@ public class LoggingAspect {
 		final String methodName = joinPoint.getSignature().getName();
 		final Object[] args = joinPoint.getArgs();
 
-		log.info("==> Method: {}.{}() | Args: {}", className, methodName, Arrays.toString(args));
+		log.info("==> Method: {}.{}()", className, methodName);
 
 		// 원래 메소드 실행
 		long startTime = System.currentTimeMillis();
@@ -42,7 +40,7 @@ public class LoggingAspect {
 		long executionTime = endTime - startTime;
 
 		// 메소드 실행 후 로그
-		log.info("<== Method: {}.{}() | Result: {} | Execution Time: {}ms", className, methodName, result, executionTime);
+		log.info("<== Method: {}.{}() | Execution Time: {}ms", className, methodName, executionTime);
 
 		return result;
 	}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/loadtest/ReservationControllerForLoadTest.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/loadtest/ReservationControllerForLoadTest.java
@@ -1,4 +1,4 @@
-package wisoft.nextframe.schedulereservationticketing.controller.reservation;
+package wisoft.nextframe.schedulereservationticketing.controller.loadtest;
 
 import java.util.UUID;
 

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/loadtest/SeatControllerForLoadTest.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/loadtest/SeatControllerForLoadTest.java
@@ -1,0 +1,34 @@
+package wisoft.nextframe.schedulereservationticketing.controller.loadtest;
+
+import java.util.UUID;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import wisoft.nextframe.schedulereservationticketing.common.response.ApiResponse;
+import wisoft.nextframe.schedulereservationticketing.dto.seat.seatstate.SeatStateListResponse;
+import wisoft.nextframe.schedulereservationticketing.service.seat.SeatStateService;
+
+@Profile("loadtest")
+@RestController
+@RequestMapping("/api/v1/loadtest/schedules")
+@RequiredArgsConstructor
+public class SeatControllerForLoadTest {
+
+	private final SeatStateService seatStateService;
+
+	@GetMapping("/{scheduleId}/seat-states")
+	public ResponseEntity<ApiResponse<?>> getLockedSeats(@PathVariable UUID scheduleId) {
+		final SeatStateListResponse data = seatStateService.getSeatStates(scheduleId);
+
+		final ApiResponse<SeatStateListResponse> response = ApiResponse.success(data);
+
+		return ResponseEntity.status(HttpStatus.OK).body(response);
+	}
+}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/loadtest/StadiumControllerForLoadTest.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/loadtest/StadiumControllerForLoadTest.java
@@ -1,0 +1,34 @@
+package wisoft.nextframe.schedulereservationticketing.controller.loadtest;
+
+import java.util.UUID;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import wisoft.nextframe.schedulereservationticketing.common.response.ApiResponse;
+import wisoft.nextframe.schedulereservationticketing.dto.seat.seatdefinition.SeatDefinitionListResponse;
+import wisoft.nextframe.schedulereservationticketing.service.seat.SeatDefinitionService;
+
+@Profile("loadtest")
+@RestController
+@RequestMapping("/api/v1/loadtest/stadiums")
+@RequiredArgsConstructor
+public class StadiumControllerForLoadTest {
+
+	private final SeatDefinitionService seatDefinitionService;
+
+	@GetMapping("/{id}/seat-definitions")
+	public ResponseEntity<ApiResponse<?>> getSeatDefinitions(@PathVariable UUID id) {
+		final SeatDefinitionListResponse data = seatDefinitionService.getSeatDefinitions(id);
+
+		final ApiResponse<SeatDefinitionListResponse> response = ApiResponse.success(data);
+
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/seat/SeatStateRepository.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/seat/SeatStateRepository.java
@@ -21,7 +21,7 @@ public interface SeatStateRepository extends JpaRepository<SeatState, SeatStateI
 	 * @param seatIds 좌석 ID 목록
 	 * @return 잠금이 적용된 SeatState 엔티티 목록
 	 */
-	@Lock(LockModeType.PESSIMISTIC_FORCE_INCREMENT)
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("SELECT ss FROM SeatState ss WHERE ss.id.scheduleId = :scheduleId AND ss.id.seatId IN :seatIds")
 	List<SeatState> findAndLockByScheduleIdAndSeatIds(
 		@Param("scheduleId") UUID scheduleId,


### PR DESCRIPTION
## 🛠️ 설명 (Description)

애플리케이션 핵심 기능(좌석 조회, 예약 등)의 성능을 측정하고 병목 지점을 파악하기 위해, 부하 테스트 전용 API 엔드포인트를 구현했습니다.

이 API들은 @Profile("loadtest") 어노테이션을 통해 loadtest 스프링 프로파일이 활성화된 환경에서만 동작합니다. 이는 부하 테스트 스크립트 작성을 용이하게 하는 것을 목표로 합니다.

## 📄 설계 문서 (Design Document)

## ✅ 테스트 계획 (Test Plan)

본 PR은 부하 테스트를 수행하기 위한 인프라 코드입니다. 테스트는 다음과 같이 진행합니다.
- loadtest 프로파일을 활성화하여 애플리케이션을 실행
- Postman을 사용하여 아래 변경 사항 요약에 명시된 3가지 API 엔드포인트가 모두 정상적으로 응답하는지 수동 테스트 완료
- 부하테스트 스크립트를 작성하여 간단한 시나리오(좌석 조회 -> 예약) 테스트 수행

## 📝 변경 사항 요약 (Summary)

- StadiumControllerForLoadTest 추가
- SeatControllerForLoadTest 추가
- ReservationControllerForLoadTest 추가

## 🔗 관련 이슈 (Related Issues)

- Closed #124 

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)
