### PR TITLE
#128 refactor(reservation): 예매 동시성 최적화 (트랜잭션 범위 및 락 전략)

### DIFF
--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/schedule/Schedule.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/schedule/Schedule.java
@@ -68,20 +68,16 @@ public class Schedule {
 			.map(SeatDefinition::getId)
 			.toList();
 
-		// 2. 좌석을 조회함과 동시에 잠급니다.
-		final List<SeatState> seatStates = seatStateRepository.findAndLockByScheduleIdAndSeatIds(this.id, seatIds);
+		// 2. 좌석을 조회합니다.
+		final List<SeatState> seatStates = seatStateRepository.findByScheduleIdAndSeatIds(this.id, seatIds);
 
 		// 3. 요청한 모든 좌석이 존재하는지 확인합니다.
 		if (seatStates.size() != seatIds.size()) {
 			throw new DomainException(ErrorCode.SEAT_NOT_DEFINED);
 		}
 
-		// 4. 이미 잠겨 있는 좌석이 있는지 확인합니다.
+		// 4. 좌석을 잠금 처리합니다.
 		for (final SeatState seatState : seatStates) {
-			if (seatState.getIsLocked()) {
-				throw new DomainException(ErrorCode.SEAT_ALREADY_LOCKED);
-			}
-			// 5. 좌석 상태를 잠금으로 변경합니다.
 			seatState.lock();
 		}
 	}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/seat/SeatState.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/seat/SeatState.java
@@ -8,11 +8,14 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
+import wisoft.nextframe.schedulereservationticketing.common.exception.ErrorCode;
 import wisoft.nextframe.schedulereservationticketing.entity.schedule.Schedule;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.SeatDefinition;
 
@@ -40,7 +43,14 @@ public class SeatState {
 	@Column(name = "is_locked", nullable = false)
 	private Boolean isLocked;
 
+	@Version
+	@Column(name = "version")
+	private Long version;
+
 	public void lock() {
+		if (this.isLocked) {
+			throw new DomainException(ErrorCode.SEAT_ALREADY_LOCKED);
+		}
 		this.isLocked = true;
 	}
 }

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/seat/SeatStateRepository.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/seat/SeatStateRepository.java
@@ -4,26 +4,24 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import jakarta.persistence.LockModeType;
 import wisoft.nextframe.schedulereservationticketing.entity.seat.SeatState;
 import wisoft.nextframe.schedulereservationticketing.entity.seat.SeatStateId;
 
 public interface SeatStateRepository extends JpaRepository<SeatState, SeatStateId> {
 
 	/**
-	 * [수정됨] 주어진 스케줄과 좌석 ID 목록에 해당하는 SeatState 엔티티를 비관적 쓰기 락을 걸어 조회합니다.
-	 * 이 메서드는 트랜잭션 내에서 호출되어야 합니다.
+	 * [수정됨] 비관적 락(@Lock) 어노테이션을 완전히 제거합니다.
+	 * 이 메서드는 이제 단순 조회(SELECT)만 수행합니다.
+	 *
 	 * @param scheduleId 스케줄 ID
 	 * @param seatIds 좌석 ID 목록
-	 * @return 잠금이 적용된 SeatState 엔티티 목록
+	 * @return 조회된 SeatState 엔티티 목록
 	 */
-	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("SELECT ss FROM SeatState ss WHERE ss.id.scheduleId = :scheduleId AND ss.id.seatId IN :seatIds")
-	List<SeatState> findAndLockByScheduleIdAndSeatIds(
+	List<SeatState> findByScheduleIdAndSeatIds(
 		@Param("scheduleId") UUID scheduleId,
 		@Param("seatIds") List<UUID> seatIds
 	);

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationExecutor.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationExecutor.java
@@ -16,7 +16,7 @@ import wisoft.nextframe.schedulereservationticketing.repository.seat.SeatStateRe
 
 @Service
 @RequiredArgsConstructor
-public class ReservationTransactionService {
+public class ReservationExecutor {
 
 	private final SeatStateRepository seatStateRepository;
 	private final ReservationRepository reservationRepository;


### PR DESCRIPTION
## 🛠️ 설명 (Description)

'좌석 예매' 기능(reserveSeat)은 현재 부하가 몰릴 시 심각한 성능 병목 현상을 겪고 있습니다.

1. 긴 트랜잭션 범위: 단순 정보 조회 로직까지 @Transactional에 포함되어, 불필요하게 DB 커넥션을 오래 점유합니다.
2. 비관적 락(Pessimistic Lock): PESSIMISTIC_WRITE 락으로 인해 동일 좌석 접근 시 'Lock Wait'이 발생하여 후순위 요청 스레드들이 모두 대기 상태에 빠집니다.

본 PR은 이 두 가지 문제를 동시에 해결하여, '대기'를 '즉시 실패'로 전환하고 시스템 전체의 동시성 처리 능력(TPS)을 향상시키는 것을 목적으로 합니다.

## 📄 설계 문서 (Design Document)

## ✅ 테스트 계획 (Test Plan)

- Postman으로 좌석예매에 대한 요청 응답 테스트 진행

## 📝 변경 사항 요약 (Summary)

- 트랜잭션 범위 최소화:
   - ReservationService의 @Transactional을 제거하고, 읽기/검증 로직만 남겼습니다.
   - ReservationExecutor를 신설하고 @Transactional을 적용하여, 실제 DB 쓰기(좌석 잠금, 예매 저장) 로직을 이곳으로 위임했습니다.

- 락 전략 변경 (낙관적 락):
   - SeatState 엔티티에 @Version 컬럼을 추가했습니다. (DB 스키마 변경 필요)
   - SeatStateRepository에서 @Lock(PESSIMISTIC_WRITE) 어노테이션을 제거했습니다.

## 🔗 관련 이슈 (Related Issues)

- Closed #128 

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [x] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

이 PR이 머지되고 배포되기 전에 seat_states 테이블에 대한 DB 마이그레이션이 반드시 선행되어야 합니다.

```
ALTER TABLE seat_states
ADD COLUMN version BIGINT NOT NULL DEFAULT 0;
```

## ➕ 추가 정보 (Additional Information)
