### PR TITLE
chore(release): 2025-11-11 배포(v1.2.1)

### DIFF
--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/common/aop/LoggingAspect.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/common/aop/LoggingAspect.java
@@ -1,7 +1,5 @@
 package wisoft.nextframe.schedulereservationticketing.common.aop;
 
-import java.util.Arrays;
-
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -33,7 +31,7 @@ public class LoggingAspect {
 		final String methodName = joinPoint.getSignature().getName();
 		final Object[] args = joinPoint.getArgs();
 
-		log.info("==> Method: {}.{}() | Args: {}", className, methodName, Arrays.toString(args));
+		log.info("==> Method: {}.{}()", className, methodName);
 
 		// 원래 메소드 실행
 		long startTime = System.currentTimeMillis();
@@ -42,7 +40,7 @@ public class LoggingAspect {
 		long executionTime = endTime - startTime;
 
 		// 메소드 실행 후 로그
-		log.info("<== Method: {}.{}() | Result: {} | Execution Time: {}ms", className, methodName, result, executionTime);
+		log.info("<== Method: {}.{}() | Execution Time: {}ms", className, methodName, executionTime);
 
 		return result;
 	}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/common/exception/ErrorCode.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/common/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
 	AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "유효한 인증 정보가 없습니다."),
 	LOGGED_OUT_USER(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "로그아웃된 사용자입니다. 다시 로그인해주세요."),
 	TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "토큰이 일치하지 않습니다. 비정상적인 접근입니다."),
+	EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "만료된 Refresh Token입니다."),
 
 
 	// Performance and Stadium

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/common/exception/JwtAuthenticationException.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/common/exception/JwtAuthenticationException.java
@@ -1,0 +1,14 @@
+package wisoft.nextframe.schedulereservationticketing.common.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class JwtAuthenticationException extends AuthenticationException {
+
+	public JwtAuthenticationException(String msg, Throwable cause) {
+		super(msg, cause);
+	}
+
+	public JwtAuthenticationException(String msg) {
+		super(msg);
+	}
+}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/jwt/JwtAuthenticationFilter.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/jwt/JwtAuthenticationFilter.java
@@ -1,28 +1,24 @@
 package wisoft.nextframe.schedulereservationticketing.config.jwt;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.UUID;
 
+import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
-import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
-import io.jsonwebtoken.security.SignatureException;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import wisoft.nextframe.schedulereservationticketing.common.exception.ErrorCode;
-import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
+import wisoft.nextframe.schedulereservationticketing.common.exception.JwtAuthenticationException;
+import wisoft.nextframe.schedulereservationticketing.config.security.CustomAuthenticationEntryPoint;
 
 @Slf4j
 @Component
@@ -30,20 +26,7 @@ import wisoft.nextframe.schedulereservationticketing.common.exception.DomainExce
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	private final JwtTokenProvider jwtTokenProvider;
-
-	private static final List<String> EXCLUDED_PATHS = List.of(
-		"/",
-		"/api/v1/auth/**",
-		"/api/v1/performances",
-		"/api/v1/performances/top10"
-	);
-	private final AntPathMatcher pathMatcher = new AntPathMatcher();
-
-	@Override
-	protected boolean shouldNotFilter(HttpServletRequest request) {
-		final String path = request.getRequestURI();
-		return EXCLUDED_PATHS.stream().anyMatch(p -> pathMatcher.match(p, path));
-	}
+	private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
 	@Override
 	protected void doFilterInternal(
@@ -51,42 +34,46 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		HttpServletResponse response,
 		FilterChain filterChain
 	) throws ServletException, IOException {
-		// 1. 요청 헤더에서 "Authorization" 헤더를 통해 JWT 토큰을 추출합니다.
+		// Authorization 헤더에서 JWT 토큰 추출
 		final String token = resolveToken(request);
 
 		if (StringUtils.hasText(token)) {
 			try {
-				if (!jwtTokenProvider.validateToken(token)) {
-					throw new DomainException(ErrorCode.INVALID_TOKEN);
-				}
 				// 토큰 검증 및 사용자 ID 추출
 				final UUID userId = jwtTokenProvider.getUserIdFromToken(token);
 				log.debug("JWT 토큰이 유효합니다. userId: {}", userId);
 
 				// Spring Security 인증 객체 생성 및 컨텍스트에 저장
-				final UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId, null,
-					java.util.Collections.emptyList());
+				final UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+					userId,
+					null,
+					java.util.Collections.emptyList()
+				);
+
 				SecurityContextHolder.getContext().setAuthentication(authentication);
 				log.info("사용자 인증 정보를 SecurityContext에 저장했습니다. userId: {}", userId);
 
-			} catch (SignatureException e) {
+			} catch (JwtException | IllegalArgumentException e) {
 				SecurityContextHolder.clearContext();
-				log.warn("유효하지 않은 JWT 서명입니다.");
-			} catch (MalformedJwtException e) {
-				SecurityContextHolder.clearContext();
-				log.warn("손상된 JWT 토큰입니다.");
-			} catch (ExpiredJwtException e) {
-				SecurityContextHolder.clearContext();
-				log.warn("만료된 JWT 토큰입니다.");
-			} catch (UnsupportedJwtException e) {
-				SecurityContextHolder.clearContext();
-				log.warn("지원하지 않는 JWT 토큰입니다.");
-			} catch (IllegalArgumentException e) {
-				SecurityContextHolder.clearContext();
-				log.warn("JWT 클레임이 비어있습니다.");
+				log.warn("JWT 인증 실패: {}", e.getMessage());
+
+				customAuthenticationEntryPoint.commence(
+					request,
+					response,
+					new JwtAuthenticationException("유효하지 않은 토큰입니다.", e));
+
+				return;
 			} catch (Exception e) {
 				SecurityContextHolder.clearContext();
-				log.error("JWT 필터 처리 중 알 수 없는 오류가 발생했습니다.", e);
+				log.error("JWT 필터 처리 중 알 수 없는 오류 발생", e);
+
+				customAuthenticationEntryPoint.commence(
+					request,
+					response,
+					new AuthenticationServiceException("필터 처리 중 오류 발생", e)
+				);
+
+				return;
 			}
 		}
 
@@ -98,11 +85,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	 */
 	private String resolveToken(HttpServletRequest request) {
 		final String bearerToken = request.getHeader("Authorization");
-		// 헤더 값이 존재하고 "Bearer"로 시작하는지 검증합니다.
+
 		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-			// "Bearer " 접두사(7자리)를 자르고 실제 토큰 부분만 반환합니다.
 			return bearerToken.substring(7);
 		}
+
 		return null;
 	}
 }

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/jwt/JwtTokenProvider.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/jwt/JwtTokenProvider.java
@@ -15,8 +15,8 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
-import io.jsonwebtoken.security.SignatureException;
 import lombok.extern.slf4j.Slf4j;
+import wisoft.nextframe.schedulereservationticketing.service.auth.TokenInfo;
 
 @Slf4j
 @Component
@@ -39,37 +39,40 @@ public class JwtTokenProvider {
 
 	public String generateAccessToken(UUID userId) {
 		log.debug("Access Token 생성. userId: {}", userId);
-		return generateToken(userId, accessTokenExpireTime);
+		return generateToken(userId, accessTokenExpireTime).tokenValue();
 	}
 
-	public String generateRefreshToken(UUID userId) {
+	public TokenInfo generateRefreshToken(UUID userId) {
 		log.debug("Refresh Token 생성. userId: {}", userId);
 		return generateToken(userId, refreshTokenExpireTime);
 	}
 
-	private String generateToken(UUID userId, long expireTime) {
+	private TokenInfo generateToken(UUID userId, long expireTime) {
 		final Date now = new Date();
 		final Date expiryDate = new Date(now.getTime() + expireTime);
 
-		return Jwts.builder()
-			.setSubject(userId.toString()) // 토큰의 주체로 사용자 ID(UUID)를 문자열로 사용
+		// 1. 토큰 문자열 생성
+		final String tokenValue = Jwts.builder()
+			.setSubject(userId.toString())
 			.setIssuedAt(now)
 			.setExpiration(expiryDate)
 			.signWith(key, SignatureAlgorithm.HS512)
 			.compact();
+
+		// 2. 만료 시간을 LocalDateTime으로 변환
+		final LocalDateTime expiresAt = expiryDate.toInstant()
+			.atZone(ZoneId.systemDefault())
+			.toLocalDateTime();
+
+		// 3. 두 정보를 TokenInfo 객체에 담아 반환
+		return new TokenInfo(tokenValue, expiresAt);
 	}
 
-	/**
-	 * JWT 토큰을 파싱하여 만료 시간을 LocalDateTime 객체로 반환하는 메서드
-	 */
+	// JWT 토큰을 파싱하여 만료 시간을 LocalDateTime 객체로 반환하는 메서드
 	public LocalDateTime getExpirationDateFromToken(String token) {
 		log.debug("토큰에서 만료 시간 추출 시도.");
 		// 토큰의 payload 부분(Claims)을 디코딩하여 가져옵니다.
-		final Claims claims = Jwts.parserBuilder()
-			.setSigningKey(key) // 토큰 생성 시 사용한 것과 동일한 secretKey
-			.build()
-			.parseClaimsJws(token)
-			.getBody();
+		final Claims claims = parseClaims(token);
 
 		// Claims에서 만료 시간(Date 객체)을 가져와 LocalDateTime으로 변환합니다.
 		return claims.getExpiration().toInstant()
@@ -77,36 +80,20 @@ public class JwtTokenProvider {
 			.toLocalDateTime();
 	}
 
-	/**
-	 * JWT 토큰의 유효성을 검증하는 메서드
-	 */
-	public boolean validateToken(String token) {
-		try {
-			Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
-			log.debug("토큰 검증 성공.");
-			return true;
-		} catch (SignatureException | io.jsonwebtoken.MalformedJwtException |
-						 io.jsonwebtoken.UnsupportedJwtException | IllegalArgumentException e) {
-			// 2. 클라이언트가 잘못된 토큰을 보낸 경우 WARN 레벨로 기록 (스택 트레이스 포함)
-			log.warn("유효하지 않은 JWT 토큰입니다.", e);
-		} catch (io.jsonwebtoken.ExpiredJwtException e) {
-			// 3. 토큰이 만료된 것은 예상 가능한 상황이므로, 간단히 WARN 레벨로 메시지만 기록
-			log.warn("만료된 JWT 토큰입니다. message: {}", e.getMessage());
-		}
-		return false;
-	}
-
-	/**
-	 * JWT 토큰에서 사용자 ID (UUID)를 추출하는 메서드
-	 */
+	// JWT 토큰에서 사용자 ID (UUID)를 추출하는 메서드
 	public UUID getUserIdFromToken(String token) {
 		log.debug("토큰에서 사용자 ID 추출 시도.");
-		Claims claims = Jwts.parserBuilder()
-			.setSigningKey(key)
-			.build()
-			.parseClaimsJws(token)
-			.getBody();
+		Claims claims = parseClaims(token);
 		// Subject에 저장된 UUID 문자열을 다시 UUID 객체로 변환하여 반환
 		return UUID.fromString(claims.getSubject());
+	}
+
+	// 토큰 파싱 헬퍼 메서드
+	private Claims parseClaims(String token) {
+			return Jwts.parserBuilder()
+				.setSigningKey(key)
+				.build()
+				.parseClaimsJws(token)
+				.getBody();
 	}
 }

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/security/CustomAuthenticationEntryPoint.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/security/CustomAuthenticationEntryPoint.java
@@ -24,10 +24,10 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 	public void commence(HttpServletRequest request, HttpServletResponse response,
 		AuthenticationException authException) throws IOException {
 		// 응답 내용 생성
-		final ApiResponse<?> apiErrorResponse = ApiResponse.error(ErrorCode.AUTHENTICATION_FAILED);
+		final ApiResponse<?> apiErrorResponse = ApiResponse.error(ErrorCode.INVALID_TOKEN);
 
 		// HTTP 상태 코드 설정
-		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // Status Code 401
 
 		// 응답의 Content-Type과 인코딩 설정
 		response.setContentType("application/json");

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/security/SecurityConfig.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/security/SecurityConfig.java
@@ -24,10 +24,10 @@ import wisoft.nextframe.schedulereservationticketing.config.jwt.JwtAuthenticatio
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-	private final CorsProperties corsProperties;
 	private final JwtAuthenticationFilter jwtAuthenticationFilter;
 	private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 	private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
 	private static final String[] PERMIT_URLS = {
 		"/",
 		"/api/v1/performances/**",
@@ -36,48 +36,42 @@ public class SecurityConfig {
 		"/v3/api-docs/**",
 		"/swagger-ui/**",
 		"/swagger-ui.html",
-		"/swagger-resources/**"
+		"/swagger-resources/**",
+		"/actuator/health",
+		"/actuator/prometheus",
+		"/service1/**",
+		"/service2/**"
 	};
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-		http
+		return http
 			// CSRF 보호 기능을 비활성화
 			.csrf(AbstractHttpConfigurer::disable)
+
+			// CORS 설정 비활성화
 			.cors(AbstractHttpConfigurer::disable)
 
-			// 세션을 사용하지 않으므로, STATELESS(상태 비저장)으로 설정합니다(세션 대신 토큰을 사용함).
+			// 세션을 사용하지 않으므로, STATELESS(상태 비저장)으로 설정(세션 대신 토큰을 사용함).
 			.sessionManagement(session ->
 				session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
 			// HTTP 요청에 대한 접근 권한 설정
 			.authorizeHttpRequests(authorize -> authorize
-				// 모든 사용자가 접근 가능한 경로를 지정합니다.(인증이 필요없는 접근 경로)
-				.requestMatchers("/",
-					"/api/v1/performances/**",
-					"/api/v1/tickets",
-					"/api/v1/auth/**",
-					"/v3/api-docs/**",
-					"/swagger-ui/**",
-					"/swagger-ui.html",
-					"/service1/**",
-					"/service2/**").permitAll()
+				// 모든 사용자가 접근 가능한 경로를 지정(인증이 필요없는 접근 경로)
+				.requestMatchers(PERMIT_URLS).permitAll()
 				// CORS preflight 요청 허용
 				.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
 				// 그 외의 모든 요청은 인증된 사용자만 접근할 수 있도록 설정
-				.anyRequest().authenticated()
-			);
+				.anyRequest().authenticated())
 
-		http
 			// 예외 처리 설정
 			.exceptionHandling(exceptions -> exceptions
 				.authenticationEntryPoint(customAuthenticationEntryPoint)
-				.accessDeniedHandler(customAccessDeniedHandler)
-			);
+				.accessDeniedHandler(customAccessDeniedHandler))
 
-		http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
-
-		return http.build();
+			// 인증 필터 적용
+			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+			.build();
 	}
-
 }

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/auth/AuthController.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/auth/AuthController.java
@@ -12,8 +12,8 @@ import lombok.extern.slf4j.Slf4j;
 import wisoft.nextframe.schedulereservationticketing.common.response.ApiResponse;
 import wisoft.nextframe.schedulereservationticketing.dto.auth.KaKaoSigninRequest;
 import wisoft.nextframe.schedulereservationticketing.dto.auth.SigninResponse;
-import wisoft.nextframe.schedulereservationticketing.dto.auth.tokenrefresh.TokenRefreshRequest;
-import wisoft.nextframe.schedulereservationticketing.dto.auth.tokenrefresh.TokenRefreshResponse;
+import wisoft.nextframe.schedulereservationticketing.dto.auth.TokenRefreshRequest;
+import wisoft.nextframe.schedulereservationticketing.dto.auth.TokenRefreshResponse;
 import wisoft.nextframe.schedulereservationticketing.service.auth.AuthService;
 import wisoft.nextframe.schedulereservationticketing.service.auth.OAuthService;
 

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/loadtest/ReservationControllerForLoadTest.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/loadtest/ReservationControllerForLoadTest.java
@@ -1,4 +1,4 @@
-package wisoft.nextframe.schedulereservationticketing.controller.reservation;
+package wisoft.nextframe.schedulereservationticketing.controller.loadtest;
 
 import java.util.UUID;
 

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/loadtest/SeatControllerForLoadTest.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/loadtest/SeatControllerForLoadTest.java
@@ -1,0 +1,34 @@
+package wisoft.nextframe.schedulereservationticketing.controller.loadtest;
+
+import java.util.UUID;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import wisoft.nextframe.schedulereservationticketing.common.response.ApiResponse;
+import wisoft.nextframe.schedulereservationticketing.dto.seat.seatstate.SeatStateListResponse;
+import wisoft.nextframe.schedulereservationticketing.service.seat.SeatStateService;
+
+@Profile("loadtest")
+@RestController
+@RequestMapping("/api/v1/loadtest/schedules")
+@RequiredArgsConstructor
+public class SeatControllerForLoadTest {
+
+	private final SeatStateService seatStateService;
+
+	@GetMapping("/{scheduleId}/seat-states")
+	public ResponseEntity<ApiResponse<?>> getLockedSeats(@PathVariable UUID scheduleId) {
+		final SeatStateListResponse data = seatStateService.getSeatStates(scheduleId);
+
+		final ApiResponse<SeatStateListResponse> response = ApiResponse.success(data);
+
+		return ResponseEntity.status(HttpStatus.OK).body(response);
+	}
+}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/loadtest/StadiumControllerForLoadTest.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/controller/loadtest/StadiumControllerForLoadTest.java
@@ -1,0 +1,34 @@
+package wisoft.nextframe.schedulereservationticketing.controller.loadtest;
+
+import java.util.UUID;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import wisoft.nextframe.schedulereservationticketing.common.response.ApiResponse;
+import wisoft.nextframe.schedulereservationticketing.dto.seat.seatdefinition.SeatDefinitionListResponse;
+import wisoft.nextframe.schedulereservationticketing.service.seat.SeatDefinitionService;
+
+@Profile("loadtest")
+@RestController
+@RequestMapping("/api/v1/loadtest/stadiums")
+@RequiredArgsConstructor
+public class StadiumControllerForLoadTest {
+
+	private final SeatDefinitionService seatDefinitionService;
+
+	@GetMapping("/{id}/seat-definitions")
+	public ResponseEntity<ApiResponse<?>> getSeatDefinitions(@PathVariable UUID id) {
+		final SeatDefinitionListResponse data = seatDefinitionService.getSeatDefinitions(id);
+
+		final ApiResponse<SeatDefinitionListResponse> response = ApiResponse.success(data);
+
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/dto/auth/TokenRefreshRequest.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/dto/auth/TokenRefreshRequest.java
@@ -1,4 +1,4 @@
-package wisoft.nextframe.schedulereservationticketing.dto.auth.tokenrefresh;
+package wisoft.nextframe.schedulereservationticketing.dto.auth;
 
 import lombok.Getter;
 

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/dto/auth/TokenRefreshResponse.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/dto/auth/TokenRefreshResponse.java
@@ -1,4 +1,4 @@
-package wisoft.nextframe.schedulereservationticketing.dto.auth.tokenrefresh;
+package wisoft.nextframe.schedulereservationticketing.dto.auth;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/schedule/Schedule.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/schedule/Schedule.java
@@ -68,20 +68,16 @@ public class Schedule {
 			.map(SeatDefinition::getId)
 			.toList();
 
-		// 2. 좌석을 조회함과 동시에 잠급니다.
-		final List<SeatState> seatStates = seatStateRepository.findAndLockByScheduleIdAndSeatIds(this.id, seatIds);
+		// 2. 좌석을 조회합니다.
+		final List<SeatState> seatStates = seatStateRepository.findByScheduleIdAndSeatIds(this.id, seatIds);
 
 		// 3. 요청한 모든 좌석이 존재하는지 확인합니다.
 		if (seatStates.size() != seatIds.size()) {
 			throw new DomainException(ErrorCode.SEAT_NOT_DEFINED);
 		}
 
-		// 4. 이미 잠겨 있는 좌석이 있는지 확인합니다.
+		// 4. 좌석을 잠금 처리합니다.
 		for (final SeatState seatState : seatStates) {
-			if (seatState.getIsLocked()) {
-				throw new DomainException(ErrorCode.SEAT_ALREADY_LOCKED);
-			}
-			// 5. 좌석 상태를 잠금으로 변경합니다.
 			seatState.lock();
 		}
 	}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/seat/SeatState.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/seat/SeatState.java
@@ -8,11 +8,14 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
+import wisoft.nextframe.schedulereservationticketing.common.exception.ErrorCode;
 import wisoft.nextframe.schedulereservationticketing.entity.schedule.Schedule;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.SeatDefinition;
 
@@ -40,7 +43,14 @@ public class SeatState {
 	@Column(name = "is_locked", nullable = false)
 	private Boolean isLocked;
 
+	@Version
+	@Column(name = "version")
+	private Long version;
+
 	public void lock() {
+		if (this.isLocked) {
+			throw new DomainException(ErrorCode.SEAT_ALREADY_LOCKED);
+		}
 		this.isLocked = true;
 	}
 }

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/seat/SeatStateRepository.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/seat/SeatStateRepository.java
@@ -4,26 +4,24 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import jakarta.persistence.LockModeType;
 import wisoft.nextframe.schedulereservationticketing.entity.seat.SeatState;
 import wisoft.nextframe.schedulereservationticketing.entity.seat.SeatStateId;
 
 public interface SeatStateRepository extends JpaRepository<SeatState, SeatStateId> {
 
 	/**
-	 * [수정됨] 주어진 스케줄과 좌석 ID 목록에 해당하는 SeatState 엔티티를 비관적 쓰기 락을 걸어 조회합니다.
-	 * 이 메서드는 트랜잭션 내에서 호출되어야 합니다.
+	 * [수정됨] 비관적 락(@Lock) 어노테이션을 완전히 제거합니다.
+	 * 이 메서드는 이제 단순 조회(SELECT)만 수행합니다.
+	 *
 	 * @param scheduleId 스케줄 ID
 	 * @param seatIds 좌석 ID 목록
-	 * @return 잠금이 적용된 SeatState 엔티티 목록
+	 * @return 조회된 SeatState 엔티티 목록
 	 */
-	@Lock(LockModeType.PESSIMISTIC_FORCE_INCREMENT)
 	@Query("SELECT ss FROM SeatState ss WHERE ss.id.scheduleId = :scheduleId AND ss.id.seatId IN :seatIds")
-	List<SeatState> findAndLockByScheduleIdAndSeatIds(
+	List<SeatState> findByScheduleIdAndSeatIds(
 		@Param("scheduleId") UUID scheduleId,
 		@Param("seatIds") List<UUID> seatIds
 	);

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/user/RefreshTokenRepository.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/user/RefreshTokenRepository.java
@@ -4,6 +4,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import wisoft.nextframe.schedulereservationticketing.entity.user.RefreshToken;
 import wisoft.nextframe.schedulereservationticketing.entity.user.User;
@@ -11,4 +13,7 @@ import wisoft.nextframe.schedulereservationticketing.entity.user.User;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, UUID> {
 
 	Optional<RefreshToken> findByUser(User user);
+
+	@Query("SELECT r FROM RefreshToken r JOIN FETCH r.user WHERE r.user.id = :userId")
+	Optional<RefreshToken> findByUserIdWithUser(@Param("userId") UUID userId);
 }

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/auth/AuthService.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/auth/AuthService.java
@@ -1,21 +1,20 @@
 package wisoft.nextframe.schedulereservationticketing.service.auth;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
 import wisoft.nextframe.schedulereservationticketing.common.exception.ErrorCode;
 import wisoft.nextframe.schedulereservationticketing.config.jwt.JwtTokenProvider;
-import wisoft.nextframe.schedulereservationticketing.dto.auth.tokenrefresh.TokenRefreshResponse;
+import wisoft.nextframe.schedulereservationticketing.dto.auth.TokenRefreshResponse;
 import wisoft.nextframe.schedulereservationticketing.entity.user.RefreshToken;
-import wisoft.nextframe.schedulereservationticketing.entity.user.User;
-import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
 import wisoft.nextframe.schedulereservationticketing.repository.user.RefreshTokenRepository;
-import wisoft.nextframe.schedulereservationticketing.repository.user.UserRepository;
 
 @Slf4j
 @Service
@@ -24,69 +23,44 @@ import wisoft.nextframe.schedulereservationticketing.repository.user.UserReposit
 public class AuthService {
 
 	private final RefreshTokenRepository refreshTokenRepository;
-	private final UserRepository userRepository;
 	private final JwtTokenProvider jwtTokenProvider;
 
 	@Transactional
 	public TokenRefreshResponse reissueToken(String refreshTokenValue) {
-		// 1. Refresh Token 유효성 검증
-		if (!jwtTokenProvider.validateToken(refreshTokenValue)) {
-			log.warn("유효하지 않은 Refresh Token으로 재발급 시도.");
+		UUID userId;
+		try {
+			userId = jwtTokenProvider.getUserIdFromToken(refreshTokenValue);
+		} catch (ExpiredJwtException e) {
+			userId = UUID.fromString(e.getClaims().getSubject());
+			log.warn("만료된 Refresh Token으로 재발급 시도. userId: {}", userId);
+			throw new DomainException(ErrorCode.EXPIRED_REFRESH_TOKEN);
+		} catch (JwtException | IllegalArgumentException e) {
+			log.warn("유효하지 않은 Refresh Token으로 재발급 시도. Error: {}", e.getMessage());
 			throw new DomainException(ErrorCode.INVALID_TOKEN);
 		}
-
-		// 2. Refresh Token에서 사용자 ID 추출
-		final UUID userId = jwtTokenProvider.getUserIdFromToken(refreshTokenValue);
 		log.debug("토큰 재발급 요청. userId: {}", userId);
 
-		final User user = userRepository.findById(userId)
-			.orElseThrow(() -> {
-				log.warn("토큰은 유효하지만 DB에 존재하지 않는 사용자. userId: {}", userId);
-				return new DomainException(ErrorCode.USER_NOT_FOUND);
-			});
+		final UUID finalUserId = userId;
 
-		// 3. DB에 저장된 Refresh Token과 일치하는지 확인
-		final RefreshToken refreshToken = refreshTokenRepository.findByUser(user)
+		final RefreshToken refreshToken = refreshTokenRepository.findByUserIdWithUser(userId)
 			.orElseThrow(() -> {
-				log.warn("로그아웃 처리된 사용자의 토큰으로 재발급 시도. userId: {}", userId);
+				log.warn("로그아웃 처리되었거나 DB에 존재하지 않는 토큰으로 재발급 시도. userId: {}", finalUserId);
+				// 이 경우, 토큰은 유효하지만 DB에 없으므로 로그아웃된 사용자로 간주하는 것이 더 정확합니다.
 				return new DomainException(ErrorCode.LOGGED_OUT_USER);
 			});
+
+		// DB에 저장된 토큰과 일치하는지 최종 확인 (탈취 방지)
 		if (!refreshToken.getTokenValue().equals(refreshTokenValue)) {
 			log.error("DB의 토큰과 불일치. 탈취 가능성 의심. userId: {}", userId);
+			refreshTokenRepository.delete(refreshToken); // 탈취 의심 토큰 즉시 삭제
 			throw new DomainException(ErrorCode.TOKEN_MISMATCH);
 		}
 
-		// 4. 새로운 Access Token 생성
-		final String newAccessToken = jwtTokenProvider.generateAccessToken(user.getId());
-		log.debug("새 Access Token 생성 완료. userId: {}", userId);
+		// 새로운 Access Token 생성
+		final String newAccessToken = jwtTokenProvider.generateAccessToken(refreshToken.getUser().getId());
+		log.info("Access Token 재발급 성공. userId: {}", userId);
 
 		return new TokenRefreshResponse(newAccessToken);
-	}
-
-	/**
-	 * Refresh Token을 DB에 저장하거나 이미 존재하면 업데이트합니다.
-	 * (OAuthService로부터 이동)
-	 * @param user 사용자 엔티티
-	 * @param tokenValue 저장할 리프레시 토큰 값
-	 * @param expiresAt 토큰 만료 시간
-	 */
-	@Transactional
-	public void saveOrUpdateRefreshToken(User user, String tokenValue, LocalDateTime expiresAt) {
-		refreshTokenRepository.findByUser(user)
-			.ifPresentOrElse(
-				refreshToken -> {
-					log.debug("Refresh Token 업데이트. userId: {}", user.getId());
-					refreshToken.updateTokenValue(tokenValue, expiresAt);
-				},
-				() -> {
-					log.debug("신규 Refresh Token 저장. userId: {}", user.getId());
-					refreshTokenRepository.save(RefreshToken.builder()
-						.user(user)                 // 어떤 사용자의 토큰인지
-						.tokenValue(tokenValue)     // 실제 토큰 값
-						.expiresAt(expiresAt)       // 토큰 만료 시간
-						.build());
-				}
-			);
 	}
 }
 

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/auth/DynamicAuthService.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/auth/DynamicAuthService.java
@@ -2,13 +2,12 @@ package wisoft.nextframe.schedulereservationticketing.service.auth;
 
 import java.util.UUID;
 
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
-import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
-import wisoft.nextframe.schedulereservationticketing.common.exception.ErrorCode;
 import wisoft.nextframe.schedulereservationticketing.entity.user.User;
 import wisoft.nextframe.schedulereservationticketing.repository.performance.PerformanceRepository;
 import wisoft.nextframe.schedulereservationticketing.repository.user.UserRepository;
@@ -38,7 +37,7 @@ public class DynamicAuthService {
 
 		// 4. UUID로 캐스팅합니다.
 		final User user = userRepository.findById(userId)
-			.orElseThrow(() -> new DomainException(ErrorCode.USER_NOT_FOUND));
+			.orElseThrow(() -> new AccessDeniedException("사용자 정보를 찾을 수 없어 인가 처리를 진행할 수 없습니다."));
 
 		return user.isAdult();
 	}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/auth/OAuthService.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/auth/OAuthService.java
@@ -1,81 +1,27 @@
 package wisoft.nextframe.schedulereservationticketing.service.auth;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import wisoft.nextframe.schedulereservationticketing.config.jwt.JwtTokenProvider;
 import wisoft.nextframe.schedulereservationticketing.dto.auth.KakaoUserInfoResponse;
 import wisoft.nextframe.schedulereservationticketing.dto.auth.SigninResponse;
-import wisoft.nextframe.schedulereservationticketing.entity.user.User;
-import wisoft.nextframe.schedulereservationticketing.repository.user.UserRepository;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class OAuthService {
 
-	private final UserRepository userRepository;
-	private final JwtTokenProvider jwtTokenProvider;
-	private final AuthService authService;
 	private final KakaoApiClient kakaoApiClient;
+	private final OAuthSigninService oAuthSiginService;
 
-	/**
-	 * 인가 코드를 받아 카카오 로그인을 처리하는 메서드
-	 */
-	@Transactional
 	public SigninResponse kakaoSignin(String provider, String authCode) {
-		// 1. 외부 API 연동은 KakaoApiClient에 위임
 		log.debug("카카오 Access Token 요청 시작.");
 		final String kakaoAccessToken = kakaoApiClient.getKakaoAccessToken(authCode);
 		log.debug("카카오 사용자 정보 요청 시작.");
 		final KakaoUserInfoResponse userInfo = kakaoApiClient.getKakaoUserInfo(kakaoAccessToken);
 		log.debug("카카오 사용자 정보 수신 완료. email: {}", userInfo.getKakaoAccount().getEmail());
 
-		// 2. 사용자 정보로 DB에서 회원을 찾거나, 없으면 새로 가입 (핵심 비즈니스 로직)
-		final User user = saveOrUpdateUser(userInfo, provider);
-
-		// 3. 우리 서비스 자체 JWT(Access Token, Refresh Token)를 생성
-		final String accessToken = jwtTokenProvider.generateAccessToken(user.getId());
-		final String refreshTokenValue = jwtTokenProvider.generateRefreshToken(user.getId());
-		log.debug("내부 JWT 생성 완료. userId: {}", user.getId());
-
-		// 4. Refresh Token 저장 로직은 AuthService에 위임
-		final LocalDateTime refreshTokenExpiresAt = jwtTokenProvider.getExpirationDateFromToken(refreshTokenValue);
-		authService.saveOrUpdateRefreshToken(user, refreshTokenValue, refreshTokenExpiresAt);
-
-		return SigninResponse.from(
-			accessToken,
-			refreshTokenValue,
-			user.getImageUrl(),
-			user.getName(),
-			user.getBirthDate(),
-			user.getEmail()
-		);
-	}
-
-	private User saveOrUpdateUser(KakaoUserInfoResponse userInfo, String provider) {
-		final String email = userInfo.getKakaoAccount().getEmail();
-		final String nickname = userInfo.getKakaoAccount().getProfile().getNickname();
-		final String imageUrl = userInfo.getKakaoAccount().getProfile().getProfileImageUrl();
-
-		return userRepository.findByEmailAndProvider(email, provider)
-			.map(user -> {
-				log.info("기존 회원 로그인. email: {}", email);
-				return user.updateProfile(nickname, imageUrl);
-			}) // 이미 존재하면 프로필 업데이트
-			.orElseGet(() -> {
-				log.info("신규 회원 가입. email: {}", email);
-				return userRepository.save(User.builder() // 없으면 새로 생성하여 저장
-				.email(email)
-				.name(nickname)
-				.imageUrl(imageUrl)
-				.provider(provider)
-				.birthDate(LocalDate.of(1998, 4, 7))
-				.build());});
+		return oAuthSiginService.processUserSignin(provider, userInfo);
 	}
 }

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/auth/OAuthSigninService.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/auth/OAuthSigninService.java
@@ -1,0 +1,76 @@
+package wisoft.nextframe.schedulereservationticketing.service.auth;
+
+import java.time.LocalDate;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import wisoft.nextframe.schedulereservationticketing.config.jwt.JwtTokenProvider;
+import wisoft.nextframe.schedulereservationticketing.dto.auth.KakaoUserInfoResponse;
+import wisoft.nextframe.schedulereservationticketing.dto.auth.SigninResponse;
+import wisoft.nextframe.schedulereservationticketing.entity.user.User;
+import wisoft.nextframe.schedulereservationticketing.repository.user.UserRepository;
+
+/**
+ * OAuth 인증 후, 실제 비즈니스 로직을 처리하는 서비스 클래스
+ * 조회/가입 및 내부 JWT 토큰 발급 처리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OAuthSigninService {
+
+	private final UserRepository userRepository;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final RefreshTokenService refreshTokenService;
+
+	@Transactional
+	SigninResponse processUserSignin(String provider, KakaoUserInfoResponse userInfo) {
+		// 사용자 정보로 DB에서 회원을 찾거나, 없으면 새로 가입
+		final User user = saveOrUpdateUser(userInfo, provider);
+
+		// 우리 서비스 자체 JWT(Access Token, Refresh Token)를 생성
+		final String accessToken = jwtTokenProvider.generateAccessToken(user.getId());
+		final TokenInfo refreshTokenInfo = jwtTokenProvider.generateRefreshToken(user.getId());
+		log.debug("내부 JWT 생성 완료. userId: {}", user.getId());
+
+		// Refresh Token 저장
+		refreshTokenService.saveOrUpdateRefreshToken(
+			user,
+			refreshTokenInfo.tokenValue(),
+			refreshTokenInfo.expiresAt()
+		);
+
+		return SigninResponse.from(
+			accessToken,
+			refreshTokenInfo.tokenValue(),
+			user.getImageUrl(),
+			user.getName(),
+			user.getBirthDate(),
+			user.getEmail()
+		);
+	}
+
+	private User saveOrUpdateUser(KakaoUserInfoResponse userInfo, String provider) {
+		final String email = userInfo.getKakaoAccount().getEmail();
+		final String nickname = userInfo.getKakaoAccount().getProfile().getNickname();
+		final String imageUrl = userInfo.getKakaoAccount().getProfile().getProfileImageUrl();
+
+		return userRepository.findByEmailAndProvider(email, provider)
+			.map(user -> {
+				log.info("기존 회원 로그인. email: {}", email);
+				return user.updateProfile(nickname, imageUrl);
+			}) // 이미 존재하면 프로필 업데이트
+			.orElseGet(() -> {
+				log.info("신규 회원 가입. email: {}", email);
+				return userRepository.save(User.builder() // 없으면 새로 생성하여 저장
+					.email(email)
+					.name(nickname)
+					.imageUrl(imageUrl)
+					.provider(provider)
+					.birthDate(LocalDate.of(1998, 4, 7))
+					.build());});
+	}
+}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/auth/RefreshTokenService.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/auth/RefreshTokenService.java
@@ -1,0 +1,49 @@
+package wisoft.nextframe.schedulereservationticketing.service.auth;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import wisoft.nextframe.schedulereservationticketing.entity.user.RefreshToken;
+import wisoft.nextframe.schedulereservationticketing.entity.user.User;
+import wisoft.nextframe.schedulereservationticketing.repository.user.RefreshTokenRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RefreshTokenService {
+
+	private final RefreshTokenRepository refreshTokenRepository;
+
+	/**
+	 * 특정 사용자의 Refresh Token을 저장하거나 이미 존재하면 새 값으로 업데이트합니다.
+	 * 모든 작업은 트랜잭션 내에서 안전하게 처리됩니다.
+	 *
+	 * @param user        사용자 엔티티
+	 * @param tokenValue  저장할 리프레시 토큰 값
+	 * @param expiresAt   토큰 만료 시간
+	 */
+	public void saveOrUpdateRefreshToken(User user, String tokenValue, LocalDateTime expiresAt) {
+		refreshTokenRepository.findByUser(user)
+			.ifPresentOrElse(
+				refreshToken -> {
+					log.debug("Refresh Token 업데이트. userId: {}", user.getId());
+					// 기존 토큰의 값과 만료 시간을 업데이트합니다.
+					refreshToken.updateTokenValue(tokenValue, expiresAt);
+				},
+				() -> {
+					log.debug("신규 Refresh Token 저장. userId: {}", user.getId());
+					// 새 Refresh Token 엔티티를 생성하여 저장합니다.
+					refreshTokenRepository.save(RefreshToken.builder()
+						.user(user)
+						.tokenValue(tokenValue)
+						.expiresAt(expiresAt)
+						.build());
+				}
+			);
+	}
+}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/auth/TokenInfo.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/auth/TokenInfo.java
@@ -1,0 +1,14 @@
+package wisoft.nextframe.schedulereservationticketing.service.auth;
+
+import java.time.LocalDateTime;
+
+/**
+ * JWT의 값과 만료 시간 정보를 함께 전달하기 위한 DTO
+ * * @param tokenValue  실제 JWT 문자열
+ * @param expiresAt   토큰의 만료 시간
+ */
+public record TokenInfo(
+	String tokenValue,
+	LocalDateTime expiresAt
+) {
+}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationExecutor.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationExecutor.java
@@ -1,0 +1,48 @@
+package wisoft.nextframe.schedulereservationticketing.service.reservation;
+
+import java.util.List;
+
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import wisoft.nextframe.schedulereservationticketing.entity.reservation.Reservation;
+import wisoft.nextframe.schedulereservationticketing.entity.schedule.Schedule;
+import wisoft.nextframe.schedulereservationticketing.entity.stadium.SeatDefinition;
+import wisoft.nextframe.schedulereservationticketing.entity.user.User;
+import wisoft.nextframe.schedulereservationticketing.repository.reservation.ReservationRepository;
+import wisoft.nextframe.schedulereservationticketing.repository.seat.SeatStateRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationExecutor {
+
+	private final SeatStateRepository seatStateRepository;
+	private final ReservationRepository reservationRepository;
+	private final ReservationFactory reservationFactory;
+
+	/**
+	 * 실제 예매(좌석 잠금, 예매 정보 생성)를 담당하는 트랜잭션 메서드입니다.
+	 *
+	 * @CacheEvict: 트랜잭션이 성공적으로 커밋될 때만 캐시를 제거합니다.
+	 */
+	@Transactional
+	@CacheEvict(cacheNames = "seatStates", key = "#schedule.id")
+	public Reservation executeReservation(
+		Schedule schedule,
+		List<SeatDefinition> seats,
+		User user,
+		int calculatedTotalPrice
+	) {
+		// 5. 예매 좌석에 대한 검증 및 잠금 처리를 합니다.
+		// (이 로직은 이제 트랜잭션 안에서 수행됩니다.)
+		schedule.lockSeatsForReservation(seats, seatStateRepository);
+
+		// 6. 예매 정보를 생성 및 저장합니다.
+		final Reservation reservation = reservationFactory.create(user, schedule, seats, calculatedTotalPrice);
+		reservationRepository.save(reservation);
+
+		return reservation;
+	}
+}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationService.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationService.java
@@ -3,12 +3,12 @@ package wisoft.nextframe.schedulereservationticketing.service.reservation;
 import java.util.List;
 import java.util.UUID;
 
-import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
 import wisoft.nextframe.schedulereservationticketing.common.exception.ErrorCode;
 import wisoft.nextframe.schedulereservationticketing.dto.reservation.request.ReservationRequest;
 import wisoft.nextframe.schedulereservationticketing.dto.reservation.response.ReservationResponse;
@@ -17,23 +17,17 @@ import wisoft.nextframe.schedulereservationticketing.entity.reservation.Reservat
 import wisoft.nextframe.schedulereservationticketing.entity.schedule.Schedule;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.SeatDefinition;
 import wisoft.nextframe.schedulereservationticketing.entity.user.User;
-import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
-import wisoft.nextframe.schedulereservationticketing.repository.reservation.ReservationRepository;
-import wisoft.nextframe.schedulereservationticketing.repository.seat.SeatStateRepository;
 
 @Slf4j
 @RequiredArgsConstructor
 @Service
 public class ReservationService {
 
-	private final SeatStateRepository seatStateRepository;
-	private final ReservationRepository reservationRepository;
 	private final PriceCalculator priceCalculator;
-	private final ReservationFactory reservationFactory;
 	private final ReservationDataProvider dataProvider;
 
-	@CacheEvict(cacheNames = "seatStates", key = "#request.scheduleId")
-	@Transactional
+	private final ReservationExecutor reservationExecutor;
+
 	public ReservationResponse reserveSeat(UUID userId, ReservationRequest request) {
 		// 1. 예매에 필요한 데이터를 준비합니다.
 		final ReservationContext context = dataProvider.provide(userId, request);
@@ -60,15 +54,23 @@ public class ReservationService {
 		}
 		log.debug("요청 금액 검증 통과.");
 
-		// 5. 예매 좌석에 대한 검증 및 잠금 처리를 합니다.
-		log.debug("좌석 잠금 처리 시작. seats: {}", seats.stream().map(SeatDefinition::getId).toList());
-		schedule.lockSeatsForReservation(seats, seatStateRepository);
-		log.debug("좌석 잠금 처리 성공.");
 
-		// 6. 예매 정보를 생성 및 저장합니다.
-		final Reservation reservation = reservationFactory.create(user, schedule, seats, calculatedTotalPrice);
-		reservationRepository.save(reservation);
-		log.debug("예매 정보 저장 완료. reservationId: {}", reservation.getId());
+		// 5. 예매 좌석 잠금 처리, 예매 진행
+		final Reservation reservation;
+		try {
+			log.debug("좌석 잠금 및 예매 정보 저장 트랜잭션 시작...");
+			reservation = reservationExecutor.executeReservation(
+				schedule,
+				seats,
+				user,
+				calculatedTotalPrice
+			);
+			log.debug("트랜잭션 완료. reservationId: {}", reservation.getId());
+		} catch (OptimisticLockingFailureException ex) {
+			log.warn("좌석 선점 경합 발생 (Optimistic Lock Failed). userId: {}, scheduleId: {}, seats: {}",
+				userId, schedule.getId(), seats.stream().map(SeatDefinition::getId).toList());
+			throw new DomainException(ErrorCode.SEAT_ALREADY_LOCKED);
+		}
 
 		// 7. 응답 DTO 생성 및 반환합니다.
 		return ReservationResponse.from(reservation, performance, schedule, seats);


### PR DESCRIPTION
## ⚡️ 성능 & 안정성 개선: 인증 로직 리팩토링 및 예매 락 최적화
Closes: #124, #126, #128

## 📝 개요
이번 릴리즈(v1.3.0)는 시스템의 핵심 병목 지점을 해결하고 코드의 유지보수성을 높이는 데 중점을 두었습니다.

1. 예매 시스템: 동시성 문제의 근원이었던 **비관적 락(Pessimistic Lock)**을 **낙관적 락(Optimistic Lock)**으로 변경하여 'Lock Wait' 병목을 제거하고 처리량을 크게 향상시켰습니다.
2. 인증/보안: 트랜잭션 범위 문제와 SRP(단일 책임 원칙) 위반 등 복잡하게 얽혀있던 OAuth 및 JWT 인증 로직을 전면 리팩토링하여 성능과 안정성, 확장성을 확보했습니다.
3. 성능 테스트: 위 변경 사항들을 대규모 트래픽 환경에서 검증하기 위한 부하 테스트 전용 API를 추가했습니다.

## ✨ 주요 변경 사항

1. 예매 시스템 병목 현상 해결 및 성능 최적화 (#128)
핵심 비즈니스인 '좌석 예매' 과정에서 발생하던 병목 현상을 해결했습니다.
- 락 전략 변경 (비관적 → 낙관적)
   - 기존 PESSIMISTIC_WRITE로 인한 DB 커넥션 병목 및 'Lock Wait' 타임아웃 문제를 해결하기 위해, @Version을 이용한 **낙관적 락(Optimistic Lock)**으로 전략을 변경했습니다.
   - 이를 통해 동시 예매 요청 처리 성능이 크게 향상되었습니다.
   - OptimisticLockingFailureException (버전 충돌) 예외 처리 로직을 추가하여 안전하게 동시성 충돌을 감지합니다.
- 트랜잭션 범위 최소화
   - reserveSeat 메서드의 트랜잭션 범위를 최소화하기 위해, 실제 DB 쓰기 로직을 ReservationTransactionService로 분리했습니다.
   - 좌석 조회, 가격 계산 등 읽기/검증 로직을 트랜잭션 외부로 분리하여 DB 커넥션 점유 시간을 크게 단축시켰습니다.
 
2. 인증/보안 시스템 전면 리팩토링 (#126)
유지보수가 어렵고 잠재적 성능 이슈가 있던 인증/보안 관련 코드를 대대적으로 개선했습니다.

- OAuth 로그인 로직 최적화 (셀프 호출 문제 해결)
   - OAuthService 내에서 외부 API 호출과 DB 작업을 분리하여 트랜잭션 범위를 최소화했습니다.
   - 트랜잭션이 적용된 DB 로직을 OAuthSignInService로 분리하여, Spring AOP의 셀프 호출(self-invocation) 문제를 해결하고 트랜잭션이 안정적으로 동작하도록 수정했습니다.
- 서비스 책임 분리 (SRP)
   - RefreshToken의 CRUD를 전담하는 RefreshTokenService를 도입했습니다.
   - AuthService는 토큰 재발급, OAuthService는 소셜 로그인 로직만 담당하도록 책임을 명확히 분리했습니다.
- JWT 로직 개선 및 최적화
   - JwtAuthenticationFilter에서 URL 제외 로직을 제거하고, 모든 인가 처리를 SecurityConfig로 일원화했습니다.
   - JwtTokenProvider의 중복된 토큰 파싱 로직을 parseClaims 헬퍼 메서드로 통합했습니다.
   - AuthService(토큰 재발급)에서 JOIN FETCH를 사용, 2번 발생하던 DB 조회를 1회로 최적화했습니다.
- SecurityConfig 가독성 향상
   - HttpSecurity 설정을 단일 메서드 체인으로 통합하고, 허용 URL 목록(PERMIT_URLS)을 상수로 분리하여 관리를 용이하게 했습니다.

3. 부하 테스트 전용 API 구현 (#124)
위의 성능 개선 사항을 검증하기 위해 대규모 트래픽을 발생시킬 수 있는 전용 API를 추가했습니다.

- @Profile("loadtest") 어노테이션을 사용하여 운영 코드와 완벽하게 분리했습니다.
- 테스트 편의성을 위해 인증 절차 대신 X-USER-ID 헤더로 사용자를 식별합니다.
- 좌석 조회, 스케줄별 좌석 상태 조회, 좌석 예약 API 등 핵심 시나리오를 구현했습니다.

## 👨‍💻 리뷰어 중점 확인 사항
이번 PR은 시스템의 근간이 되는 부분을 크게 변경하였습니다. 아래 사항들을 중점적으로 확인 부탁드립니다.

1. 낙관적 락 예외 처리: OptimisticLockingFailureException 발생 시, 사용자에게 적절한 피드백(e.g., "좌석 예매에 실패했습니다. 다시 시도해주세요.")이 전달되는지 흐름을 확인해주세요.
2. OAuth 로그인 및 토큰 재발급: OAuthSignInService 및 RefreshTokenService 분리 이후에도, 신규 소셜 로그인 및 토큰 재발급 플로우가 의도대로 정확하게 동작하는지 전체적인 테스트가 필요합니다.
3. 인가 설정: SecurityConfig의 PERMIT_URLS에 새로 추가되거나 변경된 API 경로가 누락되지 않았는지 확인 부탁드립니다.
