### PR TITLE
#135 refactor(schedule): Schedule 엔티티 내 Repository 의존성 제거

### DIFF
--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/schedule/Schedule.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/schedule/Schedule.java
@@ -17,13 +17,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
 import wisoft.nextframe.schedulereservationticketing.common.exception.ErrorCode;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.Performance;
 import wisoft.nextframe.schedulereservationticketing.entity.seat.SeatState;
-import wisoft.nextframe.schedulereservationticketing.entity.stadium.SeatDefinition;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.Stadium;
-import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
-import wisoft.nextframe.schedulereservationticketing.repository.seat.SeatStateRepository;
 
 @Getter
 @Builder
@@ -62,21 +60,13 @@ public class Schedule {
 	@Column(name = "ticket_close_time")
 	private LocalDateTime ticketCloseTime;
 
-	public void lockSeatsForReservation(List<SeatDefinition> seats, SeatStateRepository seatStateRepository) {
-		// 1. 좌석 ID 목록을 추출합니다.
-		final List<UUID> seatIds = seats.stream()
-			.map(SeatDefinition::getId)
-			.toList();
-
-		// 2. 좌석을 조회합니다.
-		final List<SeatState> seatStates = seatStateRepository.findByScheduleIdAndSeatIds(this.id, seatIds);
-
-		// 3. 요청한 모든 좌석이 존재하는지 확인합니다.
-		if (seatStates.size() != seatIds.size()) {
+	public void lockSeatsForReservation(List<SeatState> seatStates, int seatSize) {
+		// 1. 좌석이 존재하는지 확인
+		if (seatStates.size() != seatSize) {
 			throw new DomainException(ErrorCode.SEAT_NOT_DEFINED);
 		}
 
-		// 4. 좌석을 잠금 처리합니다.
+		// 2. 좌석 잠금 처리(SeatState 엔티티)
 		for (final SeatState seatState : seatStates) {
 			seatState.lock();
 		}

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationExecutorTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationExecutorTest.java
@@ -1,0 +1,170 @@
+package wisoft.nextframe.schedulereservationticketing.service.reservation;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import wisoft.nextframe.schedulereservationticketing.builder.PerformanceBuilder;
+import wisoft.nextframe.schedulereservationticketing.builder.ReservationBuilder;
+import wisoft.nextframe.schedulereservationticketing.builder.ScheduleBuilder;
+import wisoft.nextframe.schedulereservationticketing.builder.SeatDefinitionBuilder;
+import wisoft.nextframe.schedulereservationticketing.builder.SeatStateBuilder;
+import wisoft.nextframe.schedulereservationticketing.builder.StadiumBuilder;
+import wisoft.nextframe.schedulereservationticketing.builder.StadiumSectionBuilder;
+import wisoft.nextframe.schedulereservationticketing.builder.UserBuilder;
+import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
+import wisoft.nextframe.schedulereservationticketing.common.exception.ErrorCode;
+import wisoft.nextframe.schedulereservationticketing.entity.performance.Performance;
+import wisoft.nextframe.schedulereservationticketing.entity.reservation.Reservation;
+import wisoft.nextframe.schedulereservationticketing.entity.schedule.Schedule;
+import wisoft.nextframe.schedulereservationticketing.entity.seat.SeatState;
+import wisoft.nextframe.schedulereservationticketing.entity.stadium.SeatDefinition;
+import wisoft.nextframe.schedulereservationticketing.entity.stadium.Stadium;
+import wisoft.nextframe.schedulereservationticketing.entity.stadium.StadiumSection;
+import wisoft.nextframe.schedulereservationticketing.entity.user.User;
+import wisoft.nextframe.schedulereservationticketing.repository.reservation.ReservationRepository;
+import wisoft.nextframe.schedulereservationticketing.repository.seat.SeatStateRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationExecutorTest {
+
+	@InjectMocks
+	private ReservationExecutor reservationExecutor;
+
+	@Mock
+	private SeatStateRepository seatStateRepository;
+	@Mock
+	private ReservationRepository reservationRepository;
+	@Mock
+	private ReservationFactory reservationFactory;
+
+	// 공통 테스트 데이터
+	private User user;
+	private Schedule schedule;
+	private Schedule spySchedule;
+	private UUID scheduleId;
+	private UUID seatId1;
+	private UUID seatId2;
+	private List<SeatDefinition> seats;
+
+	@BeforeEach
+	void setUp() {
+		// 사용자
+		user = UserBuilder.builder().build();
+		ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+
+		// 공연/경기장/스케줄
+		Performance performance = PerformanceBuilder.builder().build();
+		Stadium stadium = StadiumBuilder.builder().build();
+		schedule = ScheduleBuilder.builder()
+			.withPerformance(performance)
+			.withStadium(stadium)
+			.build();
+		spySchedule = spy(schedule);
+		scheduleId = UUID.randomUUID();
+		ReflectionTestUtils.setField(spySchedule, "id", scheduleId);
+
+		// 구역/좌석 2개
+		StadiumSection section = StadiumSectionBuilder.builder()
+			.withStadium(stadium)
+			.build();
+
+		SeatDefinition seat1 = SeatDefinitionBuilder.builder()
+			.withStadiumSection(section)
+			.build();
+		SeatDefinition seat2 = SeatDefinitionBuilder.builder()
+			.withStadiumSection(section)
+			.build();
+		seatId1 = UUID.randomUUID();
+		seatId2 = UUID.randomUUID();
+		ReflectionTestUtils.setField(seat1, "id", seatId1);
+		ReflectionTestUtils.setField(seat2, "id", seatId2);
+		seats = List.of(seat1, seat2);
+	}
+
+	@Test
+	@DisplayName("예매 실행 성공: 좌석 상태 잠금, 예매 생성/저장, 반환 검증")
+	void executeReservation_success() {
+		// given: SeatStateRepository 조회값 세팅(좌석 수와 동일하게 2개)
+		final SeatState ss1 = SeatStateBuilder.builder()
+			.withScheduleId(scheduleId)
+			.withSeatId(seatId1)
+			.withIsLocked(false)
+			.build();
+		final SeatState ss2 = SeatStateBuilder.builder()
+			.withScheduleId(scheduleId)
+			.withSeatId(seatId2)
+			.withIsLocked(false)
+			.build();
+		given(seatStateRepository.findByScheduleIdAndSeatIds(eq(scheduleId), anyList()))
+			.willReturn(List.of(ss1, ss2));
+
+		// ReservationFactory가 생성해 줄 예약 객체
+		final Reservation reservation = ReservationBuilder.builder()
+			.withSchedule(schedule)
+			.withUser(user)
+			.build();
+		ReflectionTestUtils.setField(reservation, "id", UUID.randomUUID());
+		final int totalPrice = 200000;
+		given(reservationFactory.create(eq(user), eq(spySchedule), eq(seats), eq(totalPrice)))
+			.willReturn(reservation);
+
+		// when
+		final Reservation result = reservationExecutor.executeReservation(
+			spySchedule,
+			seats,
+			user,
+			totalPrice
+		);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result).isSameAs(reservation);
+
+		// 좌석 상태 잠금이 수행되어 isLocked=true가 되었는지 확인
+		assertThat(ss1.getIsLocked()).isTrue();
+		assertThat(ss2.getIsLocked()).isTrue();
+
+		// 내부 협력 객체 호출 검증
+		verify(seatStateRepository).findByScheduleIdAndSeatIds(
+			eq(scheduleId),
+			argThat(ids -> ids.containsAll(List.of(seatId1, seatId2)) && ids.size() == 2)
+		);
+		verify(spySchedule).lockSeatsForReservation(List.of(ss1, ss2), 2);
+		verify(reservationFactory).create(user, spySchedule, seats, totalPrice);
+		verify(reservationRepository).save(reservation);
+	}
+
+	@Test
+	@DisplayName("예매 실행 실패: 조회된 좌석 상태 수가 선택 좌석 수와 다르면 SEAT_NOT_DEFINED 예외")
+	void executeReservation_fail_seatCountMismatch() {
+		// given: SeatStateRepository는 1개만 반환하여 불일치 유도
+		final SeatState onlyOne = SeatStateBuilder.builder()
+			.withScheduleId(scheduleId)
+			.withSeatId(seatId1)
+			.withIsLocked(false)
+			.build();
+		given(seatStateRepository.findByScheduleIdAndSeatIds(eq(scheduleId), anyList()))
+			.willReturn(List.of(onlyOne));
+
+		// when and then
+		assertThatThrownBy(() -> reservationExecutor.executeReservation(spySchedule, seats, user, 10000))
+			.isInstanceOf(DomainException.class)
+			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.SEAT_NOT_DEFINED);
+
+		// 실패 시 생성/저장은 일어나지 않음
+		verify(reservationFactory, never()).create(any(), any(), any(), anyInt());
+		verify(reservationRepository, never()).save(any());
+	}
+}


### PR DESCRIPTION
## 🛠️ 설명 (Description)

기존 Schedule 엔티티 내부에 존재하던 SeatStateRepository 의존성을 제거하고, 해당 조회 로직을 서비스 계층인 ReservationExecutor로 이동시키는 리팩토링을 수행했습니다.

## 📄 설계 문서 (Design Document)

## ✅ 테스트 계획 (Test Plan)

## 📝 변경 사항 요약 (Summary)

- Schedule 엔티티: lockSeatsForReservation 메서드 파라미터에서 SeatStateRepository 제거
- Schedule 엔티티: 조회된 List<SeatState>와 requestCount를 인자로 받도록 메서드 시그니처 변경
- ReservationExecutor 서비스: SeatState 조회 로직(seatStateRepository.findBy...) 추가 및 엔티티 메서드 호출부 수정

## 🔗 관련 이슈 (Related Issues)

- Closed #135 

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [x] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)
- 비즈니스 로직 자체(좌석 개수 검증, Lock 처리)는 변경되지 않았으며, **데이터를 가져오는 위치**만 엔티티 내부에서 서비스로 이동했습니다.

## ➕ 추가 정보 (Additional Information)
