### PR TITLE
fix: Review.likeCount에 @Builder.Default 적용

### DIFF
--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/review/Review.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/review/Review.java
@@ -52,6 +52,7 @@ public class Review {
 	private BigDecimal star;
 
 	@Column(name = "like_count")
+	@Builder.Default
 	private Integer likeCount = 0;
 
 	@CreationTimestamp


### PR DESCRIPTION
## 🛠️ 설명 (Description)

Lombok `@Builder` 사용 시 필드 초기값이 무시되어
`Review.likeCount`가 null로 생성될 수 있는 문제를 수정했습니다.

`@Builder.Default`를 적용하여
빌더를 통해 생성되더라도 기본값 0이 유지되도록 변경했습니다.

<img width="1670" height="143" alt="image" src="https://github.com/user-attachments/assets/daed91a1-44a1-4110-af8d-29087369cf0e" />

## 📝 변경 사항 요약 (Summary)

- Review.likeCount 필드에 @Builder.Default 적용
- Builder 사용 시 likeCount가 null로 생성되는 잠재적 NPE 방지

## 🔗 관련 이슈 (Related Issues)

없음

## ☑️ 체크리스트 (Checklist)

- [x]  코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 변경 사항에 대한 문서화가 완료되었습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)
Lombok `@Builder` 사용 시 필드 초기화 표현식이 무시된다는 경고에 따른 수정입니다.
기존 동작 의도(리뷰 생성 시 좋아요 수는 항상 0에서 시작)를 명확히 하기 위한 변경입니다.