### PR TITLE
#156 fix(performance): Redis 캐시 역직렬화 오류 수정

### DIFF
--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/db/RedisCacheConfig.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/db/RedisCacheConfig.java
@@ -16,7 +16,11 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 @Configuration
@@ -28,8 +32,18 @@ public class RedisCacheConfig {
 	 */
 	@Bean
 	public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+		PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
+			.allowIfSubType("wisoft.nextframe.schedulereservationticketing.dto")
+			.allowIfSubType("wisoft.nextframe.schedulereservationticketing.entity")
+			.allowIfSubType("java.util")
+			.allowIfSubType("java.time")
+			.build();
+
 		ObjectMapper objectMapper = new ObjectMapper();
 		objectMapper.registerModule(new JavaTimeModule());
+		objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+		// DefaultTyping 설정 활성화
+		objectMapper.activateDefaultTyping(typeValidator, ObjectMapper.DefaultTyping.EVERYTHING, JsonTypeInfo.As.PROPERTY);
 
 		GenericJackson2JsonRedisSerializer redisSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
 

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/dto/performance/performancelist/response/PerformanceSummaryResponse.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/dto/performance/performancelist/response/PerformanceSummaryResponse.java
@@ -4,22 +4,20 @@ import java.time.LocalDate;
 import java.util.Date;
 import java.util.UUID;
 
-import lombok.Getter;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.PerformanceGenre;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.PerformanceType;
 
-@Getter
-public class PerformanceSummaryResponse {
-
-	private final UUID id;
-	private final String name;
-	private final String imageUrl;
-	private final PerformanceType type;
-	private final PerformanceGenre genre;
-	private final String stadiumName;
-	private final LocalDate startDate;
-	private final LocalDate endDate;
-	private final Boolean adultOnly;
+public record PerformanceSummaryResponse(
+	UUID id,
+	String name,
+	String imageUrl,
+	PerformanceType type,
+	PerformanceGenre genre,
+	String stadiumName,
+	LocalDate startDate,
+	LocalDate endDate,
+	Boolean adultOnly
+) {
 
 	public PerformanceSummaryResponse(
 		UUID id,
@@ -32,14 +30,15 @@ public class PerformanceSummaryResponse {
 		Date endDate,
 		Boolean adultOnly
 	) {
-		this.id = id;
-		this.name = name;
-		this.imageUrl = imageUrl;
-		this.type = type;
-		this.genre = genre;
-		this.stadiumName = stadiumName;
-		this.startDate = ((java.sql.Date) startDate).toLocalDate();
-		this.endDate = ((java.sql.Date) endDate).toLocalDate();
-		this.adultOnly = adultOnly;
+		this(id,
+			name,
+			imageUrl,
+			type,
+			genre,
+			stadiumName,
+			((java.sql.Date) startDate).toLocalDate(),
+			((java.sql.Date) endDate).toLocalDate(),
+			adultOnly
+		);
 	}
 }

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryTest.java
@@ -85,9 +85,9 @@ class PerformanceRepositoryTest {
 			assertThat(resultPage.getTotalElements()).isEqualTo(1);
 
 			final PerformanceSummaryResponse performanceSummaryResponse = resultPage.getContent().getFirst();
-			assertThat(performanceSummaryResponse.getId()).isEqualTo(performance.getId());
-			assertThat(performanceSummaryResponse.getStartDate()).isEqualTo(now.plusDays(30).toLocalDate());
-			assertThat(performanceSummaryResponse.getEndDate()).isEqualTo(now.plusDays(50).toLocalDate());
+			assertThat(performanceSummaryResponse.id()).isEqualTo(performance.getId());
+			assertThat(performanceSummaryResponse.startDate()).isEqualTo(now.plusDays(30).toLocalDate());
+			assertThat(performanceSummaryResponse.endDate()).isEqualTo(now.plusDays(50).toLocalDate());
 		}
 
 		@Test
@@ -109,7 +109,7 @@ class PerformanceRepositoryTest {
 
 			// then
 			final boolean found = resultPage.getContent().stream()
-				.anyMatch(dto -> dto.getId().equals(performance.getId()));
+				.anyMatch(dto -> dto.id().equals(performance.getId()));
 
 			assertThat(found).isFalse();
 		}
@@ -133,7 +133,7 @@ class PerformanceRepositoryTest {
 
 			// then
 			final boolean found = resultPage.getContent().stream()
-				.anyMatch(dto -> dto.getId().equals(performance.getId()));
+				.anyMatch(dto -> dto.id().equals(performance.getId()));
 
 			assertThat(found).isFalse();
 		}
@@ -179,12 +179,12 @@ class PerformanceRepositoryTest {
 
 			// 2. 제외되어야 할 공연들이 조회되지 않았는지 확인
 			assertThat(resultPage.getContent())
-				.extracting(PerformanceSummaryResponse::getName)
+				.extracting(PerformanceSummaryResponse::name)
 				.doesNotContain("11위 공연(미포함)", "종료된 인기공연(미포함)");
 
 			// 3. 정렬 순서가 정확한지 확인한다. (조회수 DESC, 시작일 ASC)
 			assertThat(resultPage.getContent())
-				.extracting(PerformanceSummaryResponse::getName)
+				.extracting(PerformanceSummaryResponse::name)
 				.containsExactly(
 					"1위 공연",
 					"2위 공연",


### PR DESCRIPTION
## 🛠️ 설명 (Description)

Redis 캐시가 적용된 API 조회 시 java.util.LinkedHashMap cannot be cast to ... 형태의 ClassCastException이 발생하는 문제를 해결했습니다.

기존 설정에서는 Redis 저장 시 JSON에 클래스 타입 정보가 포함되지 않아, 역직렬화 시 구체적인 DTO 객체가 아닌 단순 LinkedHashMap으로 변환되는 문제가 있었습니다. 이를 해결하기 위해 RedisCacheConfig의 ObjectMapper 설정을 고도화했습니다.

## 📄 설계 문서 (Design Document)

## ✅ 테스트 계획 (Test Plan)

- 로컬 환경 테스트: /api/v1/performances 등 캐시가 적용된 API 호출 시 500 에러 없이 정상적으로 JSON 응답이 반환되는지 확인.
- Redis 데이터 확인: redis-cli를 통해 저장된 값을 확인했을 때, JSON 내부에 ["wisoft...DTO", { ... }] 형태의 클래스 타입 정보(@class)가 포함되어 있는지 검증.

## 📝 변경 사항 요약 (Summary)

ObjectMapper 타입 정보 활성화 (activateDefaultTyping)
- BasicPolymorphicTypeValidator를 적용하여 보안을 유지하면서, JSON 직렬화 시 클래스 정보(패키지 경로 등)를 함께 저장하도록 설정했습니다.
- 이를 통해 역직렬화 시 LinkedHashMap이 아닌 원본 DTO 타입으로 안전하게 복원됩니다.

알 수 없는 속성 무시 (FAIL_ON_UNKNOWN_PROPERTIES = false)
- 추후 DTO 필드가 변경되거나 삭제되더라도, Redis에 남아있는 구버전 데이터 때문에 에러가 발생하지 않도록 설정을 추가했습니다.

## 🔗 관련 이슈 (Related Issues)

- Closed #156 
- Related #이슈번호

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 테스트 코드가 작성되었고, 통과했습니다.
- [x] 변경 사항에 대한 문서화가 완료되었습니다.
- [x] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)
