### PR TITLE
#166 feat: 예매 타임아웃 처리 구현

### DIFF
--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/ScheduleReservationTicketingApplication.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/ScheduleReservationTicketingApplication.java
@@ -5,8 +5,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableCaching
+@EnableScheduling
 @SpringBootApplication(exclude = RedisRepositoriesAutoConfiguration.class)
 @ConfigurationPropertiesScan
 public class ScheduleReservationTicketingApplication {

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/common/exception/ErrorCode.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/common/exception/ErrorCode.java
@@ -30,11 +30,13 @@ public enum ErrorCode {
 
 	// Reservation
 	SEAT_ALREADY_LOCKED(HttpStatus.CONFLICT, "CONFLICT", "이미 예약되었거나 선택할 수 없는 좌석입니다."),
+	SEAT_NOT_LOCKED(HttpStatus.CONFLICT, "CONFLICT", "잠금 상태가 아닌 좌석입니다."),
 	INVALID_SEAT_SELECTION_COUNT(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "좌석은 1개 이상, 4개 이하로 선택해야 합니다."),
 	TOTAL_PRICE_MISMATCH(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "요청한 금액과 계산된 금액이 일치하지 않습니다."),
 	SEAT_NOT_DEFINED(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "요청한 좌석 중 일부를 찾을 수 없습니다."),
 	PERFORMANCE_SCHEDULE_MISMATCH(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "공연과 공연 일정 정보가 일치하지 않습니다."),
 	RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOT_FOUND", "해당 예약 정보를 찾을 수 없습니다."),
+	RESERVATION_ALREADY_PROCESSED(HttpStatus.CONFLICT, "CONFLICT", "이미 처리된 예약입니다."),
 
 	// Review
 	REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "NOT_FOUND", "해당 리뷰을 찾을 수 없습니다."),

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/reservation/Reservation.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/reservation/Reservation.java
@@ -22,6 +22,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -71,6 +72,9 @@ public class Reservation {
 
 	@Column(name = "expires_at")
 	private LocalDateTime expiresAt;
+
+	@Version
+	private Long version;
 
 	@Builder.Default
 	@OneToMany(mappedBy = "reservation", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/reservation/Reservation.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/reservation/Reservation.java
@@ -27,6 +27,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import wisoft.nextframe.schedulereservationticketing.common.exception.DomainException;
+import wisoft.nextframe.schedulereservationticketing.common.exception.ErrorCode;
 import wisoft.nextframe.schedulereservationticketing.entity.schedule.Schedule;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.SeatDefinition;
 import wisoft.nextframe.schedulereservationticketing.entity.user.User;
@@ -38,6 +40,8 @@ import wisoft.nextframe.schedulereservationticketing.entity.user.User;
 @Entity
 @Table(name = "reservations")
 public class Reservation {
+
+	private static final int EXPIRATION_MINUTES = 10;
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
@@ -65,6 +69,9 @@ public class Reservation {
 	@Column(name = "reserved_at", nullable = false, updatable = false)
 	private LocalDateTime reservedAt;
 
+	@Column(name = "expires_at")
+	private LocalDateTime expiresAt;
+
 	@Builder.Default
 	@OneToMany(mappedBy = "reservation", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<ReservationSeat> reservationSeats = new ArrayList<>();
@@ -74,7 +81,22 @@ public class Reservation {
 			.user(user)
 			.schedule(schedule)
 			.totalPrice(totalPrice)
+			.expiresAt(LocalDateTime.now().plusMinutes(EXPIRATION_MINUTES))
 			.build();
+	}
+
+	public void confirm() {
+		if (this.status != ReservationStatus.CREATED) {
+			throw new DomainException(ErrorCode.RESERVATION_ALREADY_PROCESSED);
+		}
+		this.status = ReservationStatus.CONFIRMED;
+	}
+
+	public void cancel() {
+		if (this.status != ReservationStatus.CREATED) {
+			throw new DomainException(ErrorCode.RESERVATION_ALREADY_PROCESSED);
+		}
+		this.status = ReservationStatus.CANCELLED;
 	}
 
 	// 연관 관계 편의 메서드

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/seat/SeatState.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/entity/seat/SeatState.java
@@ -48,4 +48,11 @@ public class SeatState {
         }
         this.isLocked = true;
     }
+
+    public void unlock() {
+        if (!this.isLocked) {
+            throw new DomainException(ErrorCode.SEAT_NOT_LOCKED);
+        }
+        this.isLocked = false;
+    }
 }

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/reservation/ReservationRepository.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/reservation/ReservationRepository.java
@@ -1,5 +1,7 @@
 package wisoft.nextframe.schedulereservationticketing.repository.reservation;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 import wisoft.nextframe.schedulereservationticketing.entity.performance.Performance;
 import wisoft.nextframe.schedulereservationticketing.entity.reservation.Reservation;
+import wisoft.nextframe.schedulereservationticketing.entity.reservation.ReservationStatus;
 import wisoft.nextframe.schedulereservationticketing.entity.user.User;
 
 public interface ReservationRepository extends JpaRepository<Reservation, UUID> {
@@ -23,4 +26,12 @@ public interface ReservationRepository extends JpaRepository<Reservation, UUID> 
 		"FROM Reservation r " +
 		"WHERE r.user = :user AND r.schedule.performance = :performance")
 	boolean existsByUserAndPerformance(@Param("user") User user, @Param("performance") Performance performance);
+
+	@Query("SELECT r FROM Reservation r " +
+		"JOIN FETCH r.reservationSeats " +
+		"WHERE r.status = :status AND r.expiresAt < :now")
+	List<Reservation> findExpiredReservations(
+		@Param("status") ReservationStatus status,
+		@Param("now") LocalDateTime now
+	);
 }

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationTimeoutCanceller.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationTimeoutCanceller.java
@@ -1,0 +1,70 @@
+package wisoft.nextframe.schedulereservationticketing.service.reservation;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import wisoft.nextframe.schedulereservationticketing.entity.reservation.Reservation;
+import wisoft.nextframe.schedulereservationticketing.entity.reservation.ReservationSeat;
+import wisoft.nextframe.schedulereservationticketing.entity.reservation.ReservationStatus;
+import wisoft.nextframe.schedulereservationticketing.entity.seat.SeatState;
+import wisoft.nextframe.schedulereservationticketing.repository.reservation.ReservationRepository;
+import wisoft.nextframe.schedulereservationticketing.repository.seat.SeatStateRepository;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservationTimeoutCanceller {
+
+	private final ReservationRepository reservationRepository;
+	private final SeatStateRepository seatStateRepository;
+
+	@Transactional
+	public int cancelExpiredReservations(LocalDateTime now) {
+		final List<Reservation> expiredReservations = reservationRepository
+			.findExpiredReservations(ReservationStatus.CREATED, now);
+
+		if (expiredReservations.isEmpty()) {
+			return 0;
+		}
+
+		log.info("만료된 예약 {}건 처리 시작", expiredReservations.size());
+
+		for (final Reservation reservation : expiredReservations) {
+			cancelReservationAndUnlockSeats(reservation);
+		}
+
+		log.info("만료된 예약 {}건 처리 완료", expiredReservations.size());
+		return expiredReservations.size();
+	}
+
+	private void cancelReservationAndUnlockSeats(Reservation reservation) {
+		reservation.cancel();
+
+		final List<ReservationSeat> reservationSeats = reservation.getReservationSeats();
+
+		if (reservationSeats.isEmpty()) {
+			log.warn("예약 {}에 연결된 좌석이 없습니다.", reservation.getId());
+			return;
+		}
+
+		final UUID scheduleId = reservation.getSchedule().getId();
+		final List<UUID> seatIds = reservationSeats.stream()
+			.map(rs -> rs.getId().getSeatId())
+			.toList();
+
+		final List<SeatState> seatStates = seatStateRepository
+			.findByScheduleIdAndSeatIds(scheduleId, seatIds);
+
+		for (final SeatState seatState : seatStates) {
+			seatState.unlock();
+		}
+
+		log.info("예약 {} 취소 완료 (좌석 {}개 잠금 해제)", reservation.getId(), seatStates.size());
+	}
+}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationTimeoutCanceller.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationTimeoutCanceller.java
@@ -4,8 +4,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,24 +24,33 @@ public class ReservationTimeoutCanceller {
 
 	private final ReservationRepository reservationRepository;
 	private final SeatStateRepository seatStateRepository;
+	private final TransactionTemplate transactionTemplate;
 
-	@Transactional
 	public int cancelExpiredReservations(LocalDateTime now) {
-		final List<Reservation> expiredReservations = reservationRepository
-			.findExpiredReservations(ReservationStatus.CREATED, now);
+		final List<Reservation> expiredReservations = transactionTemplate.execute(status ->
+			reservationRepository.findExpiredReservations(ReservationStatus.CREATED, now)
+		);
 
-		if (expiredReservations.isEmpty()) {
+		if (expiredReservations == null || expiredReservations.isEmpty()) {
 			return 0;
 		}
 
 		log.info("만료된 예약 {}건 처리 시작", expiredReservations.size());
 
+		int cancelledCount = 0;
 		for (final Reservation reservation : expiredReservations) {
-			cancelReservationAndUnlockSeats(reservation);
+			try {
+				transactionTemplate.executeWithoutResult(status ->
+					cancelReservationAndUnlockSeats(reservation)
+				);
+				cancelledCount++;
+			} catch (ObjectOptimisticLockingFailureException e) {
+				log.info("예약 {}이 동시에 처리됨 (결제 확정), 건너뜀", reservation.getId());
+			}
 		}
 
-		log.info("만료된 예약 {}건 처리 완료", expiredReservations.size());
-		return expiredReservations.size();
+		log.info("만료된 예약 {}건 처리 완료", cancelledCount);
+		return cancelledCount;
 	}
 
 	private void cancelReservationAndUnlockSeats(Reservation reservation) {

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationTimeoutScheduler.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationTimeoutScheduler.java
@@ -1,0 +1,27 @@
+package wisoft.nextframe.schedulereservationticketing.service.reservation;
+
+import java.time.LocalDateTime;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservationTimeoutScheduler {
+
+	private final ReservationTimeoutCanceller reservationTimeoutCanceller;
+
+	@Scheduled(fixedRate = 60_000)
+	public void cancelExpiredReservations() {
+		int cancelledCount = reservationTimeoutCanceller
+			.cancelExpiredReservations(LocalDateTime.now());
+
+		if (cancelledCount > 0) {
+			log.info("만료 예약 취소 스케줄러: {}건 취소 완료", cancelledCount);
+		}
+	}
+}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/ticketing/TicketService.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/service/ticketing/TicketService.java
@@ -40,7 +40,10 @@ public class TicketService {
 				throw new DomainException(ErrorCode.TICKET_ALREADY_ISSUED);
 			});
 
-		// 3. 티켓 발급
+		// 3. 예약 확정
+		reservation.confirm();
+
+		// 4. 티켓 발급
 		Ticket ticket = Ticket.issue(reservation);
 		ticketRepository.saveAndFlush(ticket);
 

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/builder/ReservationBuilder.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/builder/ReservationBuilder.java
@@ -22,6 +22,7 @@ public class ReservationBuilder {
 	private Integer totalPrice = 50000;
 	private ReservationStatus status = ReservationStatus.CONFIRMED;
 	private LocalDateTime reservedAt = LocalDateTime.now();
+	private LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(10);
 	private List<ReservationSeat> reservationSeats = new ArrayList<>();
 
 	public static ReservationBuilder builder() {
@@ -39,6 +40,6 @@ public class ReservationBuilder {
 	}
 
 	public Reservation build() {
-		return new Reservation(id, user, schedule, totalPrice, status, reservedAt, reservationSeats);
+		return new Reservation(id, user, schedule, totalPrice, status, reservedAt, expiresAt, reservationSeats);
 	}
 }

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/builder/ReservationBuilder.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/builder/ReservationBuilder.java
@@ -23,6 +23,7 @@ public class ReservationBuilder {
 	private ReservationStatus status = ReservationStatus.CONFIRMED;
 	private LocalDateTime reservedAt = LocalDateTime.now();
 	private LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(10);
+	private Long version = 0L;
 	private List<ReservationSeat> reservationSeats = new ArrayList<>();
 
 	public static ReservationBuilder builder() {
@@ -40,6 +41,6 @@ public class ReservationBuilder {
 	}
 
 	public Reservation build() {
-		return new Reservation(id, user, schedule, totalPrice, status, reservedAt, expiresAt, reservationSeats);
+		return new Reservation(id, user, schedule, totalPrice, status, reservedAt, expiresAt, version, reservationSeats);
 	}
 }

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationTimeoutCancellerTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationTimeoutCancellerTest.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Consumer;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,14 +15,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import wisoft.nextframe.schedulereservationticketing.entity.reservation.Reservation;
 import wisoft.nextframe.schedulereservationticketing.entity.reservation.ReservationSeat;
 import wisoft.nextframe.schedulereservationticketing.entity.reservation.ReservationSeatId;
-import wisoft.nextframe.schedulereservationticketing.entity.reservation.ReservationStatus;
 import wisoft.nextframe.schedulereservationticketing.entity.schedule.Schedule;
 import wisoft.nextframe.schedulereservationticketing.entity.seat.SeatState;
-import wisoft.nextframe.schedulereservationticketing.repository.reservation.ReservationRepository;
 import wisoft.nextframe.schedulereservationticketing.repository.seat.SeatStateRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -31,16 +33,16 @@ class ReservationTimeoutCancellerTest {
 	private ReservationTimeoutCanceller reservationTimeoutCanceller;
 
 	@Mock
-	private ReservationRepository reservationRepository;
-	@Mock
 	private SeatStateRepository seatStateRepository;
+	@Mock
+	private TransactionTemplate transactionTemplate;
 
 	@Test
 	@DisplayName("만료된 예약이 없으면 0을 반환하고 아무 작업도 하지 않는다")
 	void cancelExpiredReservations_noExpired_returnsZero() {
 		// given
 		LocalDateTime now = LocalDateTime.now();
-		given(reservationRepository.findExpiredReservations(ReservationStatus.CREATED, now))
+		given(transactionTemplate.execute(any(TransactionCallback.class)))
 			.willReturn(Collections.emptyList());
 
 		// when
@@ -72,8 +74,12 @@ class ReservationTimeoutCancellerTest {
 		given(mockReservation.getReservationSeats()).willReturn(List.of(mockSeat1, mockSeat2));
 		given(mockReservation.getSchedule()).willReturn(mockSchedule);
 
-		given(reservationRepository.findExpiredReservations(ReservationStatus.CREATED, now))
+		given(transactionTemplate.execute(any(TransactionCallback.class)))
 			.willReturn(List.of(mockReservation));
+		willAnswer(invocation -> {
+			invocation.getArgument(0, Consumer.class).accept(null);
+			return null;
+		}).given(transactionTemplate).executeWithoutResult(any());
 
 		SeatState mockSeatState1 = mock(SeatState.class);
 		SeatState mockSeatState2 = mock(SeatState.class);
@@ -123,8 +129,12 @@ class ReservationTimeoutCancellerTest {
 		given(mockReservation2.getReservationSeats()).willReturn(List.of(mockRsSeat2));
 		given(mockReservation2.getSchedule()).willReturn(mockSchedule2);
 
-		given(reservationRepository.findExpiredReservations(ReservationStatus.CREATED, now))
+		given(transactionTemplate.execute(any(TransactionCallback.class)))
 			.willReturn(List.of(mockReservation1, mockReservation2));
+		willAnswer(invocation -> {
+			invocation.getArgument(0, Consumer.class).accept(null);
+			return null;
+		}).given(transactionTemplate).executeWithoutResult(any());
 
 		SeatState mockSeatState1 = mock(SeatState.class);
 		SeatState mockSeatState2 = mock(SeatState.class);
@@ -142,5 +152,51 @@ class ReservationTimeoutCancellerTest {
 		verify(mockReservation2).cancel();
 		verify(mockSeatState1).unlock();
 		verify(mockSeatState2).unlock();
+	}
+
+	@Test
+	@DisplayName("동시 결제로 OptimisticLockException 발생 시 해당 예약을 건너뛰고 나머지를 처리한다")
+	void cancelExpiredReservations_optimisticLockConflict_skipsAndContinues() {
+		// given
+		LocalDateTime now = LocalDateTime.now();
+
+		Reservation conflictReservation = mock(Reservation.class);
+		given(conflictReservation.getId()).willReturn(UUID.randomUUID());
+
+		Reservation normalReservation = mock(Reservation.class);
+		UUID scheduleId = UUID.randomUUID();
+		UUID seatId = UUID.randomUUID();
+
+		Schedule mockSchedule = mock(Schedule.class);
+		given(mockSchedule.getId()).willReturn(scheduleId);
+
+		ReservationSeat mockRsSeat = mock(ReservationSeat.class);
+		given(mockRsSeat.getId()).willReturn(new ReservationSeatId(UUID.randomUUID(), seatId));
+
+		given(normalReservation.getReservationSeats()).willReturn(List.of(mockRsSeat));
+		given(normalReservation.getSchedule()).willReturn(mockSchedule);
+
+		given(transactionTemplate.execute(any(TransactionCallback.class)))
+			.willReturn(List.of(conflictReservation, normalReservation));
+
+		// 첫 번째 호출: OptimisticLockException, 두 번째 호출: 정상 실행
+		willThrow(new ObjectOptimisticLockingFailureException(Reservation.class.getName(), null))
+			.willAnswer(invocation -> {
+				invocation.getArgument(0, Consumer.class).accept(null);
+				return null;
+			}).given(transactionTemplate).executeWithoutResult(any());
+
+		SeatState mockSeatState = mock(SeatState.class);
+		given(seatStateRepository.findByScheduleIdAndSeatIds(scheduleId, List.of(seatId)))
+			.willReturn(List.of(mockSeatState));
+
+		// when
+		int result = reservationTimeoutCanceller.cancelExpiredReservations(now);
+
+		// then
+		assertThat(result).isEqualTo(1);
+		verify(conflictReservation, never()).cancel();
+		verify(normalReservation).cancel();
+		verify(mockSeatState).unlock();
 	}
 }

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationTimeoutCancellerTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/service/reservation/ReservationTimeoutCancellerTest.java
@@ -1,0 +1,146 @@
+package wisoft.nextframe.schedulereservationticketing.service.reservation;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import wisoft.nextframe.schedulereservationticketing.entity.reservation.Reservation;
+import wisoft.nextframe.schedulereservationticketing.entity.reservation.ReservationSeat;
+import wisoft.nextframe.schedulereservationticketing.entity.reservation.ReservationSeatId;
+import wisoft.nextframe.schedulereservationticketing.entity.reservation.ReservationStatus;
+import wisoft.nextframe.schedulereservationticketing.entity.schedule.Schedule;
+import wisoft.nextframe.schedulereservationticketing.entity.seat.SeatState;
+import wisoft.nextframe.schedulereservationticketing.repository.reservation.ReservationRepository;
+import wisoft.nextframe.schedulereservationticketing.repository.seat.SeatStateRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationTimeoutCancellerTest {
+
+	@InjectMocks
+	private ReservationTimeoutCanceller reservationTimeoutCanceller;
+
+	@Mock
+	private ReservationRepository reservationRepository;
+	@Mock
+	private SeatStateRepository seatStateRepository;
+
+	@Test
+	@DisplayName("만료된 예약이 없으면 0을 반환하고 아무 작업도 하지 않는다")
+	void cancelExpiredReservations_noExpired_returnsZero() {
+		// given
+		LocalDateTime now = LocalDateTime.now();
+		given(reservationRepository.findExpiredReservations(ReservationStatus.CREATED, now))
+			.willReturn(Collections.emptyList());
+
+		// when
+		int result = reservationTimeoutCanceller.cancelExpiredReservations(now);
+
+		// then
+		assertThat(result).isZero();
+		verifyNoInteractions(seatStateRepository);
+	}
+
+	@Test
+	@DisplayName("만료된 예약이 있으면 예약을 취소하고 좌석 잠금을 해제한다")
+	void cancelExpiredReservations_withExpired_cancelsAndUnlocksSeats() {
+		// given
+		LocalDateTime now = LocalDateTime.now();
+		UUID scheduleId = UUID.randomUUID();
+		UUID seatId1 = UUID.randomUUID();
+		UUID seatId2 = UUID.randomUUID();
+
+		Schedule mockSchedule = mock(Schedule.class);
+		given(mockSchedule.getId()).willReturn(scheduleId);
+
+		ReservationSeat mockSeat1 = mock(ReservationSeat.class);
+		ReservationSeat mockSeat2 = mock(ReservationSeat.class);
+		given(mockSeat1.getId()).willReturn(new ReservationSeatId(UUID.randomUUID(), seatId1));
+		given(mockSeat2.getId()).willReturn(new ReservationSeatId(UUID.randomUUID(), seatId2));
+
+		Reservation mockReservation = mock(Reservation.class);
+		given(mockReservation.getReservationSeats()).willReturn(List.of(mockSeat1, mockSeat2));
+		given(mockReservation.getSchedule()).willReturn(mockSchedule);
+
+		given(reservationRepository.findExpiredReservations(ReservationStatus.CREATED, now))
+			.willReturn(List.of(mockReservation));
+
+		SeatState mockSeatState1 = mock(SeatState.class);
+		SeatState mockSeatState2 = mock(SeatState.class);
+		given(seatStateRepository.findByScheduleIdAndSeatIds(scheduleId, List.of(seatId1, seatId2)))
+			.willReturn(List.of(mockSeatState1, mockSeatState2));
+
+		// when
+		int result = reservationTimeoutCanceller.cancelExpiredReservations(now);
+
+		// then
+		assertThat(result).isEqualTo(1);
+		verify(mockReservation).cancel();
+		verify(mockSeatState1).unlock();
+		verify(mockSeatState2).unlock();
+	}
+
+	@Test
+	@DisplayName("만료된 예약이 여러 건이면 모두 취소하고 처리 건수를 반환한다")
+	void cancelExpiredReservations_multipleExpired_cancelsAll() {
+		// given
+		LocalDateTime now = LocalDateTime.now();
+
+		UUID scheduleId1 = UUID.randomUUID();
+		UUID scheduleId2 = UUID.randomUUID();
+		UUID seatId1 = UUID.randomUUID();
+		UUID seatId2 = UUID.randomUUID();
+
+		// 첫 번째 예약
+		Schedule mockSchedule1 = mock(Schedule.class);
+		given(mockSchedule1.getId()).willReturn(scheduleId1);
+
+		ReservationSeat mockRsSeat1 = mock(ReservationSeat.class);
+		given(mockRsSeat1.getId()).willReturn(new ReservationSeatId(UUID.randomUUID(), seatId1));
+
+		Reservation mockReservation1 = mock(Reservation.class);
+		given(mockReservation1.getReservationSeats()).willReturn(List.of(mockRsSeat1));
+		given(mockReservation1.getSchedule()).willReturn(mockSchedule1);
+
+		// 두 번째 예약
+		Schedule mockSchedule2 = mock(Schedule.class);
+		given(mockSchedule2.getId()).willReturn(scheduleId2);
+
+		ReservationSeat mockRsSeat2 = mock(ReservationSeat.class);
+		given(mockRsSeat2.getId()).willReturn(new ReservationSeatId(UUID.randomUUID(), seatId2));
+
+		Reservation mockReservation2 = mock(Reservation.class);
+		given(mockReservation2.getReservationSeats()).willReturn(List.of(mockRsSeat2));
+		given(mockReservation2.getSchedule()).willReturn(mockSchedule2);
+
+		given(reservationRepository.findExpiredReservations(ReservationStatus.CREATED, now))
+			.willReturn(List.of(mockReservation1, mockReservation2));
+
+		SeatState mockSeatState1 = mock(SeatState.class);
+		SeatState mockSeatState2 = mock(SeatState.class);
+		given(seatStateRepository.findByScheduleIdAndSeatIds(scheduleId1, List.of(seatId1)))
+			.willReturn(List.of(mockSeatState1));
+		given(seatStateRepository.findByScheduleIdAndSeatIds(scheduleId2, List.of(seatId2)))
+			.willReturn(List.of(mockSeatState2));
+
+		// when
+		int result = reservationTimeoutCanceller.cancelExpiredReservations(now);
+
+		// then
+		assertThat(result).isEqualTo(2);
+		verify(mockReservation1).cancel();
+		verify(mockReservation2).cancel();
+		verify(mockSeatState1).unlock();
+		verify(mockSeatState2).unlock();
+	}
+}


### PR DESCRIPTION
<!-- pr-ai-generated -->

## 🛠️ 설명 (Description)

예매 생성 후 일정 시간 내에 결제가 완료되지 않아 발생하는 예매 타임아웃을 처리하는 기능을 구현했습니다.
이를 통해 만료된 예약은 자동으로 취소되고, 해당 예약에 묶여있던 좌석들은 다시 선택 가능한 상태로 전환됩니다.
스케줄링 태스크를 도입하여 주기적으로 만료된 예약들을 감지하고 처리하도록 하였습니다.

## 📄 설계 문서 (Design Document)

N/A

## ✅ 테스트 계획 (Test Plan)

-   **유닛 테스트**: `ReservationTimeoutCancellerTest`를 통해 `ReservationTimeoutCanceller`의 핵심 로직을 테스트했습니다.
    -   만료된 예약이 없는 경우
    -   만료된 단일 예약이 정상적으로 취소되고 좌석이 잠금 해제되는 경우
    -   만료된 여러 예약이 모두 취소되고 좌석이 잠금 해제되는 경우
    -   동시성 문제(Optimistic Locking)로 인해 특정 예약이 이미 결제 확정 등으로 처리되었을 때, 해당 예약을 건너뛰고 나머지 예약을 처리하는 경우

## 📝 변경 사항 요약 (Summary)

-   **`ScheduleReservationTicketingApplication.java`**:
    -   스케줄링 활성화를 위한 `@EnableScheduling` 어노테이션을 추가했습니다.
-   **`ErrorCode.java`**:
    -   `SEAT_NOT_LOCKED` (잠금 상태가 아닌 좌석에 대한 잠금 해제 요청 시 발생하는 예외) 코드를 추가했습니다.
    -   `RESERVATION_ALREADY_PROCESSED` (이미 처리된 예약에 대한 상태 변경 요청 시 발생하는 예외) 코드를 추가했습니다.
-   **`Reservation.java`**:
    -   예약 만료 시간 (`EXPIRATION_MINUTES = 10`분) 상수를 추가했습니다.
    -   예약 만료 시각을 저장하는 `expiresAt` 필드를 추가했습니다.
    -   낙관적 락킹을 위한 `version` 필드를 추가했습니다.
    -   `create` 메서드에서 `expiresAt`을 현재 시각 + `EXPIRATION_MINUTES`로 설정하도록 로직을 추가했습니다.
    -   예약을 `CONFIRMED` 상태로 변경하고, `RESERVATION_ALREADY_PROCESSED` 예외를 처리하는 `confirm()` 메서드를 추가했습니다.
    -   예약을 `CANCELLED` 상태로 변경하고, `RESERVATION_ALREADY_PROCESSED` 예외를 처리하는 `cancel()` 메서드를 추가했습니다.
-   **`SeatState.java`**:
    -   좌석의 잠금을 해제하고, `SEAT_NOT_LOCKED` 예외를 처리하는 `unlock()` 메서드를 추가했습니다.
-   **`ReservationRepository.java`**:
    -   만료 시각이 지났고 `CREATED` 상태인 예약을 조회하는 `findExpiredReservations` JPQL 쿼리 메서드를 추가했습니다.
-   **`ReservationTimeoutCanceller.java` (신규 파일)**:
    -   만료된 예약들을 찾아 취소하고 관련 좌석의 잠금을 해제하는 비즈니스 로직을 구현했습니다.
    -   트랜잭션 관리를 위해 `TransactionTemplate`을 사용하며, 낙관적 락킹(`ObjectOptimisticLockingFailureException`) 발생 시 해당 예약을 건너뛰도록 처리했습니다.
-   **`ReservationTimeoutScheduler.java` (신규 파일)**:
    -   `@Scheduled(fixedRate = 60_000)` 어노테이션을 사용하여 1분마다 `ReservationTimeoutCanceller`를 호출하여 만료된 예약을 처리하는 스케줄링 태스크를 구현했습니다.
-   **`TicketService.java`**:
    -   `issueByReservation` 메서드에서 티켓 발급 전에 `reservation.confirm()`을 호출하여 예약 상태를 `CONFIRMED`로 명시적으로 변경하도록 추가했습니다.
-   **`ReservationBuilder.java` (테스트용)**:
    -   테스트 빌더에 `expiresAt`과 `version` 필드를 추가했습니다.
-   **`ReservationTimeoutCancellerTest.java` (신규 파일)**:
    -   `ReservationTimeoutCanceller` 컴포넌트에 대한 유닛 테스트 코드를 작성했습니다.

## 🔗 관련 이슈 (Related Issues)

-   Closed #166

## ☑️ 체크리스트 (Checklist)

-   [ ] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
-   [ ] 테스트 코드가 작성되었고, 통과했습니다.
-   [ ] 변경 사항에 대한 문서화가 완료되었습니다.
-   [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

-   `@EnableScheduling`이 `ScheduleReservationTicketingApplication`에 추가되어 스케줄링이 활성화됩니다.
-   `Reservation` 엔티티에 `expiresAt`과 `version` 필드가 추가되었으므로, DDL 변경 사항을 확인해 주세요.
-   만료된 예약 취소 로직에 낙관적 락킹(`@Version`)이 적용되어 있어, 스케줄러가 예약을 취소하려는 시점에 동시에 사용자가 결제를 완료하여 예약이 확정되는 경우를 처리합니다. 이 경우 스케줄러는 `ObjectOptimisticLockingFailureException`을 catch하고 해당 예약을 건너뛰게 됩니다.
-   스케줄러는 1분마다 실행되며, `CREATED` 상태의 만료된 예약을 찾아 처리합니다.

## ➕ 추가 정보 (Additional Information)
N/A