### PR TITLE
#170 refactor: 복잡한 JPQL을 QueryDSL로 전환

### DIFF
--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/db/QueryDslConfig.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/db/QueryDslConfig.java
@@ -1,0 +1,17 @@
+package wisoft.nextframe.schedulereservationticketing.config.db;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+
+@Configuration
+public class QueryDslConfig {
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory(final EntityManager entityManager) {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepository.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepository.java
@@ -3,87 +3,13 @@ package wisoft.nextframe.schedulereservationticketing.repository.performance;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import wisoft.nextframe.schedulereservationticketing.dto.performance.performancelist.response.PerformanceSummaryResponse;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.Performance;
 
-public interface PerformanceRepository extends JpaRepository<Performance, UUID> {
-
-	/**
-	 * 현재 예매 가능한 공연 목록을 DTO로 직접 조회합니다.
-	 *
-	 * 이 메소드는 다음 조건을 만족하는 공연을 찾습니다.
-	 * - {@code EXISTS} 서브쿼리를 사용하여 현재 시간이 티켓 판매 기간에 포함되는 공연만 필터링합니다.
-	 * - {@code GROUP BY}를 사용하여 각 공연(공연+공연장 기준)의 시작일과 종료일을
-	 * 연결된 모든 일정의 가장 빠른 날짜(MIN)와 가장 늦은 날짜(MAX)로 계산합니다.
-	 *
-	 * @param pageable 페이징 정보(페이지 번호, 페이지 크기)
-	 * @return PerformanceSummaryResponse의 페이지 객체
-	 */
-	@Query(value = """
-		    SELECT new wisoft.nextframe.schedulereservationticketing.dto.performance.performancelist.response.PerformanceSummaryResponse(
-		        p.id,
-		        p.name,
-		        p.imageUrl,
-		        p.type,
-		        p.genre,
-		        st.name,
-		        MIN(CAST(sc.performanceDatetime AS date)),
-		        MAX(CAST(sc.performanceDatetime AS date)),
-		        p.adultOnly
-		    )
-		    FROM Schedule sc
-				JOIN sc.performance p
-				JOIN sc.stadium st
-				WHERE EXISTS (
-						SELECT 1
-						FROM Schedule s_sub
-						WHERE s_sub.performance.id = p.id
-						AND s_sub.ticketOpenTime <= CURRENT_TIMESTAMP
-						AND s_sub.ticketCloseTime >= CURRENT_TIMESTAMP
-				)
-				GROUP BY p.id, p.name, p.imageUrl, p.type, p.genre, st.name, p.adultOnly
-		""")
-	Page<PerformanceSummaryResponse> findReservablePerformances(Pageable pageable);
-
-	/**
-	 * 조회수(hit)가 높은 인기 공연 10개를 DTO로 직접 조회합니다.
-	 *
-	 * 이 메소드는 다음 조건을 만족하는 공연을 찾습니다.
-	 * - PerformanceStatistic 테이블과 JOIN하여 hit 정보를 가져옵니다.
-	 * - GROUP BY를 사용하여 각 공연의 시작일과 종료일을 계산합니다.
-	 * - HAVING 절을 사용하여 공연의 마지막 날짜가 현재보다 이전인(종료된) 공연은 제외합니다.
-	 * - ORDER BY 절을 통해 조회수(hit)로 내림차순 정렬하고, 동점일 경우 공연 시작일(가장 빠른 일정) 오름차순으로 2차 정렬합니다.
-	 *
-	 * @param pageable 페이징 정보 (상위 10개를 가져오기 위해 PageRequest.of(0, 10)을 사용)
-	 * @return PerformanceSummaryResponse의 페이지 객체
-	 */
-	@Query(value = """
-        SELECT new wisoft.nextframe.schedulereservationticketing.dto.performance.performancelist.response.PerformanceSummaryResponse(
-            p.id,
-            p.name,
-            p.imageUrl,
-            p.type,
-            p.genre,
-            st.name,
-            MIN(CAST(sc.performanceDatetime AS date)),
-            MAX(CAST(sc.performanceDatetime AS date)),
-            p.adultOnly
-        )
-        FROM Schedule sc
-        JOIN sc.performance p
-        JOIN sc.stadium st
-        JOIN PerformanceStatistic ps ON ps.performance = p
-        GROUP BY p.id, p.name, p.imageUrl, p.type, p.genre, st.name, p.adultOnly, ps.hit
-        HAVING MAX(sc.performanceDatetime) >= CURRENT_TIMESTAMP
-        ORDER BY ps.hit DESC, MIN(sc.performanceDatetime) ASC
-    """)
-	Page<PerformanceSummaryResponse> findTop10Performances(Pageable pageable);
+public interface PerformanceRepository extends JpaRepository<Performance, UUID>, PerformanceRepositoryCustom {
 
 	/**
 	 * 공연 ID를 기반으로 성인 관람 여부(adultOnly)만 조회하는 메소드.

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryCustom.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryCustom.java
@@ -1,0 +1,13 @@
+package wisoft.nextframe.schedulereservationticketing.repository.performance;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import wisoft.nextframe.schedulereservationticketing.dto.performance.performancelist.response.PerformanceSummaryResponse;
+
+public interface PerformanceRepositoryCustom {
+
+	Page<PerformanceSummaryResponse> findReservablePerformances(Pageable pageable);
+
+	Page<PerformanceSummaryResponse> findTop10Performances(Pageable pageable);
+}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryImpl.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryImpl.java
@@ -13,7 +13,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.types.ConstructorExpression;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.DateTemplate;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
@@ -51,41 +53,16 @@ public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
 	 */
 	@Override
 	public Page<PerformanceSummaryResponse> findReservablePerformances(final Pageable pageable) {
-		// 메인 쿼리의 schedule과 구분하기 위해 서브쿼리용 별칭을 별도로 생성
 		final QSchedule subSchedule = new QSchedule("subSchedule");
 		final LocalDateTime now = LocalDateTime.now();
 
-		// LocalDateTime → Date 변환: MIN/MAX 집계 시 시간 부분을 제거하고 날짜만 비교
-		final DateTemplate<java.sql.Date> performanceDate =
-			Expressions.dateTemplate(java.sql.Date.class, "CAST({0} AS date)", schedule.performanceDatetime);
-
 		// 컨텐츠 쿼리: 예매 가능한 공연을 DTO로 프로젝션
 		final List<PerformanceSummaryResponse> content = queryFactory
-			.select(Projections.constructor(PerformanceSummaryResponse.class,
-				performance.id,
-				performance.name,
-				performance.imageUrl,
-				performance.type,
-				performance.genre,
-				stadium.name,
-				performanceDate.min(),
-				performanceDate.max(),
-				performance.adultOnly
-			))
+			.select(performanceSummaryProjection())
 			.from(schedule)
 			.join(schedule.performance, performance)
 			.join(schedule.stadium, stadium)
-			.where(
-				// 티켓 판매 기간에 해당하는 일정이 하나라도 존재하는 공연만 필터링
-				JPAExpressions.selectOne()
-					.from(subSchedule)
-					.where(
-						subSchedule.performance.id.eq(performance.id),
-						subSchedule.ticketOpenTime.loe(now),
-						subSchedule.ticketCloseTime.goe(now)
-					)
-					.exists()
-			)
+			.where(ticketOnSale(subSchedule, now))
 			.groupBy(
 				performance.id,
 				performance.name,
@@ -104,16 +81,7 @@ public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
 			.select(performance.id.countDistinct())
 			.from(schedule)
 			.join(schedule.performance, performance)
-			.where(
-				JPAExpressions.selectOne()
-					.from(subSchedule)
-					.where(
-						subSchedule.performance.id.eq(performance.id),
-						subSchedule.ticketOpenTime.loe(now),
-						subSchedule.ticketCloseTime.goe(now)
-					)
-					.exists()
-			);
+			.where(ticketOnSale(subSchedule, now));
 
 		return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
 	}
@@ -125,7 +93,7 @@ public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
 	 * <ul>
 	 *     <li>{@code PerformanceStatistic} 테이블과 JOIN하여 조회수(hit) 정보를 가져옵니다.</li>
 	 *     <li>{@code GROUP BY}를 사용하여 각 공연의 시작일과 종료일을 계산합니다.</li>
-	 *     <li>{@code HAVING} 절을 사용하여 공연의 마지막 날짜가 현재보다 이전인(종료된) 공연은 제외합니다.</li>
+	 *     <li>{@code EXISTS} 서브쿼리를 사용하여 현재 시간이 티켓 판매 기간에 포함되는 공연만 필터링합니다.</li>
 	 *     <li>{@code ORDER BY} 절을 통해 조회수로 내림차순 정렬하고,
 	 *         동점일 경우 공연 시작일(가장 빠른 일정) 오름차순으로 2차 정렬합니다.</li>
 	 * </ul>
@@ -135,27 +103,18 @@ public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
 	 */
 	@Override
 	public Page<PerformanceSummaryResponse> findTop10Performances(final Pageable pageable) {
-		final DateTemplate<java.sql.Date> performanceDate =
-			Expressions.dateTemplate(java.sql.Date.class, "CAST({0} AS date)", schedule.performanceDatetime);
+		final QSchedule subSchedule = new QSchedule("subSchedule");
+		final LocalDateTime now = LocalDateTime.now();
 
 		// 컨텐츠 쿼리: 조회수 기준 인기 공연을 DTO로 프로젝션
 		final List<PerformanceSummaryResponse> content = queryFactory
-			.select(Projections.constructor(PerformanceSummaryResponse.class,
-				performance.id,
-				performance.name,
-				performance.imageUrl,
-				performance.type,
-				performance.genre,
-				stadium.name,
-				performanceDate.min(),
-				performanceDate.max(),
-				performance.adultOnly
-			))
+			.select(performanceSummaryProjection())
 			.from(schedule)
 			.join(schedule.performance, performance)
 			.join(schedule.stadium, stadium)
 			// PerformanceStatistic과 연관관계가 없으므로 ON 절로 직접 조인
 			.join(performanceStatistic).on(performanceStatistic.performance.eq(performance))
+			.where(ticketOnSale(subSchedule, now))
 			.groupBy(
 				performance.id,
 				performance.name,
@@ -166,8 +125,6 @@ public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
 				performance.adultOnly,
 				performanceStatistic.hit
 			)
-			// 이미 종료된 공연 제외: 마지막 일정이 현재 시간 이후인 공연만 포함
-			.having(schedule.performanceDatetime.max().goe(LocalDateTime.now()))
 			// 1차: 조회수 내림차순, 2차: 공연 시작일 오름차순
 			.orderBy(
 				performanceStatistic.hit.desc(),
@@ -177,14 +134,54 @@ public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
 			.limit(pageable.getPageSize())
 			.fetch();
 
-		// count 쿼리: HAVING 대신 WHERE로 단순화하여 미종료 공연 수만 집계
+		// count 쿼리: content와 동일한 EXISTS 서브쿼리로 예매 가능 공연 수만 집계
 		final JPAQuery<Long> countQuery = queryFactory
 			.select(performance.id.countDistinct())
 			.from(schedule)
 			.join(schedule.performance, performance)
 			.join(performanceStatistic).on(performanceStatistic.performance.eq(performance))
-			.where(schedule.performanceDatetime.goe(LocalDateTime.now()));
+			.where(ticketOnSale(subSchedule, now));
 
 		return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+	}
+
+	/**
+	 * 티켓 판매 기간에 해당하는 일정이 하나라도 존재하는 공연만 필터링하는 EXISTS 조건을 생성합니다.
+	 *
+	 * @param subSchedule 서브쿼리용 QSchedule 별칭
+	 * @param now         기준 시간
+	 */
+	private BooleanExpression ticketOnSale(final QSchedule subSchedule, final LocalDateTime now) {
+		return JPAExpressions.selectOne()
+			.from(subSchedule)
+			.where(
+				subSchedule.performance.id.eq(performance.id),
+				subSchedule.ticketOpenTime.loe(now),
+				subSchedule.ticketCloseTime.goe(now)
+			)
+			.exists();
+	}
+
+	/**
+	 * 공연 목록 조회에 공통으로 사용되는 {@link PerformanceSummaryResponse} 프로젝션을 생성합니다.
+	 *
+	 * <p>{@code CAST(performanceDatetime AS date)}를 사용하여 시간 부분을 제거한 뒤
+	 * {@code MIN/MAX}로 공연 시작일·종료일을 집계합니다.</p>
+	 */
+	private ConstructorExpression<PerformanceSummaryResponse> performanceSummaryProjection() {
+		final DateTemplate<java.sql.Date> performanceDate =
+			Expressions.dateTemplate(java.sql.Date.class, "CAST({0} AS date)", schedule.performanceDatetime);
+
+		return Projections.constructor(PerformanceSummaryResponse.class,
+			performance.id,
+			performance.name,
+			performance.imageUrl,
+			performance.type,
+			performance.genre,
+			stadium.name,
+			performanceDate.min(),
+			performanceDate.max(),
+			performance.adultOnly
+		);
 	}
 }

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryImpl.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryImpl.java
@@ -1,0 +1,190 @@
+package wisoft.nextframe.schedulereservationticketing.repository.performance;
+
+import static wisoft.nextframe.schedulereservationticketing.entity.performance.QPerformance.*;
+import static wisoft.nextframe.schedulereservationticketing.entity.performance.QPerformanceStatistic.*;
+import static wisoft.nextframe.schedulereservationticketing.entity.schedule.QSchedule.*;
+import static wisoft.nextframe.schedulereservationticketing.entity.stadium.QStadium.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.DateTemplate;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import wisoft.nextframe.schedulereservationticketing.dto.performance.performancelist.response.PerformanceSummaryResponse;
+import wisoft.nextframe.schedulereservationticketing.entity.schedule.QSchedule;
+
+/**
+ * {@link PerformanceRepositoryCustom}의 QueryDSL 구현체.
+ *
+ * <p>복잡한 집계·서브쿼리가 필요한 공연 조회 쿼리를 타입 안전하게 처리합니다.
+ * {@link PageableExecutionUtils}를 사용하여 불필요한 count 쿼리를 지연 실행합니다.</p>
+ */
+@Repository
+@RequiredArgsConstructor
+public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	/**
+	 * 현재 예매 가능한 공연 목록을 DTO로 직접 조회합니다.
+	 *
+	 * <p>이 메소드는 다음 조건을 만족하는 공연을 찾습니다:</p>
+	 * <ul>
+	 *     <li>{@code EXISTS} 서브쿼리를 사용하여 현재 시간이 티켓 판매 기간에 포함되는 공연만 필터링합니다.</li>
+	 *     <li>{@code GROUP BY}를 사용하여 각 공연(공연+공연장 기준)의 시작일과 종료일을
+	 *         연결된 모든 일정의 가장 빠른 날짜({@code MIN})와 가장 늦은 날짜({@code MAX})로 계산합니다.</li>
+	 * </ul>
+	 *
+	 * @param pageable 페이징 정보(페이지 번호, 페이지 크기)
+	 * @return {@link PerformanceSummaryResponse}의 페이지 객체
+	 */
+	@Override
+	public Page<PerformanceSummaryResponse> findReservablePerformances(final Pageable pageable) {
+		// 메인 쿼리의 schedule과 구분하기 위해 서브쿼리용 별칭을 별도로 생성
+		final QSchedule subSchedule = new QSchedule("subSchedule");
+		final LocalDateTime now = LocalDateTime.now();
+
+		// LocalDateTime → Date 변환: MIN/MAX 집계 시 시간 부분을 제거하고 날짜만 비교
+		final DateTemplate<java.sql.Date> performanceDate =
+			Expressions.dateTemplate(java.sql.Date.class, "CAST({0} AS date)", schedule.performanceDatetime);
+
+		// 컨텐츠 쿼리: 예매 가능한 공연을 DTO로 프로젝션
+		final List<PerformanceSummaryResponse> content = queryFactory
+			.select(Projections.constructor(PerformanceSummaryResponse.class,
+				performance.id,
+				performance.name,
+				performance.imageUrl,
+				performance.type,
+				performance.genre,
+				stadium.name,
+				performanceDate.min(),
+				performanceDate.max(),
+				performance.adultOnly
+			))
+			.from(schedule)
+			.join(schedule.performance, performance)
+			.join(schedule.stadium, stadium)
+			.where(
+				// 티켓 판매 기간에 해당하는 일정이 하나라도 존재하는 공연만 필터링
+				JPAExpressions.selectOne()
+					.from(subSchedule)
+					.where(
+						subSchedule.performance.id.eq(performance.id),
+						subSchedule.ticketOpenTime.loe(now),
+						subSchedule.ticketCloseTime.goe(now)
+					)
+					.exists()
+			)
+			.groupBy(
+				performance.id,
+				performance.name,
+				performance.imageUrl,
+				performance.type,
+				performance.genre,
+				stadium.name,
+				performance.adultOnly
+			)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		// count 쿼리: PageableExecutionUtils가 마지막 페이지일 경우 실행을 생략하여 최적화
+		final JPAQuery<Long> countQuery = queryFactory
+			.select(performance.id.countDistinct())
+			.from(schedule)
+			.join(schedule.performance, performance)
+			.where(
+				JPAExpressions.selectOne()
+					.from(subSchedule)
+					.where(
+						subSchedule.performance.id.eq(performance.id),
+						subSchedule.ticketOpenTime.loe(now),
+						subSchedule.ticketCloseTime.goe(now)
+					)
+					.exists()
+			);
+
+		return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+	}
+
+	/**
+	 * 조회수(hit)가 높은 인기 공연을 DTO로 직접 조회합니다.
+	 *
+	 * <p>이 메소드는 다음 조건을 만족하는 공연을 찾습니다:</p>
+	 * <ul>
+	 *     <li>{@code PerformanceStatistic} 테이블과 JOIN하여 조회수(hit) 정보를 가져옵니다.</li>
+	 *     <li>{@code GROUP BY}를 사용하여 각 공연의 시작일과 종료일을 계산합니다.</li>
+	 *     <li>{@code HAVING} 절을 사용하여 공연의 마지막 날짜가 현재보다 이전인(종료된) 공연은 제외합니다.</li>
+	 *     <li>{@code ORDER BY} 절을 통해 조회수로 내림차순 정렬하고,
+	 *         동점일 경우 공연 시작일(가장 빠른 일정) 오름차순으로 2차 정렬합니다.</li>
+	 * </ul>
+	 *
+	 * @param pageable 페이징 정보 (상위 10개를 가져오기 위해 {@code PageRequest.of(0, 10)}을 사용)
+	 * @return {@link PerformanceSummaryResponse}의 페이지 객체
+	 */
+	@Override
+	public Page<PerformanceSummaryResponse> findTop10Performances(final Pageable pageable) {
+		final DateTemplate<java.sql.Date> performanceDate =
+			Expressions.dateTemplate(java.sql.Date.class, "CAST({0} AS date)", schedule.performanceDatetime);
+
+		// 컨텐츠 쿼리: 조회수 기준 인기 공연을 DTO로 프로젝션
+		final List<PerformanceSummaryResponse> content = queryFactory
+			.select(Projections.constructor(PerformanceSummaryResponse.class,
+				performance.id,
+				performance.name,
+				performance.imageUrl,
+				performance.type,
+				performance.genre,
+				stadium.name,
+				performanceDate.min(),
+				performanceDate.max(),
+				performance.adultOnly
+			))
+			.from(schedule)
+			.join(schedule.performance, performance)
+			.join(schedule.stadium, stadium)
+			// PerformanceStatistic과 연관관계가 없으므로 ON 절로 직접 조인
+			.join(performanceStatistic).on(performanceStatistic.performance.eq(performance))
+			.groupBy(
+				performance.id,
+				performance.name,
+				performance.imageUrl,
+				performance.type,
+				performance.genre,
+				stadium.name,
+				performance.adultOnly,
+				performanceStatistic.hit
+			)
+			// 이미 종료된 공연 제외: 마지막 일정이 현재 시간 이후인 공연만 포함
+			.having(schedule.performanceDatetime.max().goe(LocalDateTime.now()))
+			// 1차: 조회수 내림차순, 2차: 공연 시작일 오름차순
+			.orderBy(
+				performanceStatistic.hit.desc(),
+				schedule.performanceDatetime.min().asc()
+			)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		// count 쿼리: HAVING 대신 WHERE로 단순화하여 미종료 공연 수만 집계
+		final JPAQuery<Long> countQuery = queryFactory
+			.select(performance.id.countDistinct())
+			.from(schedule)
+			.join(schedule.performance, performance)
+			.join(performanceStatistic).on(performanceStatistic.performance.eq(performance))
+			.where(schedule.performanceDatetime.goe(LocalDateTime.now()));
+
+		return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+	}
+}

--- a/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryImpl.java
+++ b/schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryImpl.java
@@ -19,7 +19,6 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.DateTemplate;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -76,14 +75,19 @@ public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
 			.limit(pageable.getPageSize())
 			.fetch();
 
-		// count 쿼리: PageableExecutionUtils가 마지막 페이지일 경우 실행을 생략하여 최적화
-		final JPAQuery<Long> countQuery = queryFactory
-			.select(performance.id.countDistinct())
-			.from(schedule)
-			.join(schedule.performance, performance)
-			.where(ticketOnSale(subSchedule, now));
-
-		return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+		// count 쿼리: content의 GROUP BY(공연+공연장) 기준과 일치하도록 그룹 수를 집계
+		// QueryDSL JPA는 FROM 절 서브쿼리를 지원하지 않으므로 그룹 결과를 조회 후 size()로 총 수를 계산
+		return PageableExecutionUtils.getPage(content, pageable,
+			() -> queryFactory
+				.select(performance.id)
+				.from(schedule)
+				.join(schedule.performance, performance)
+				.join(schedule.stadium, stadium)
+				.where(ticketOnSale(subSchedule, now))
+				.groupBy(performance.id, stadium.name)
+				.fetch()
+				.size()
+		);
 	}
 
 	/**
@@ -134,15 +138,20 @@ public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
 			.limit(pageable.getPageSize())
 			.fetch();
 
-		// count 쿼리: content와 동일한 EXISTS 서브쿼리로 예매 가능 공연 수만 집계
-		final JPAQuery<Long> countQuery = queryFactory
-			.select(performance.id.countDistinct())
-			.from(schedule)
-			.join(schedule.performance, performance)
-			.join(performanceStatistic).on(performanceStatistic.performance.eq(performance))
-			.where(ticketOnSale(subSchedule, now));
-
-		return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+		// count 쿼리: content의 GROUP BY(공연+공연장) 기준과 일치하도록 그룹 수를 집계
+		// QueryDSL JPA는 FROM 절 서브쿼리를 지원하지 않으므로 그룹 결과를 조회 후 size()로 총 수를 계산
+		return PageableExecutionUtils.getPage(content, pageable,
+			() -> queryFactory
+				.select(performance.id)
+				.from(schedule)
+				.join(schedule.performance, performance)
+				.join(schedule.stadium, stadium)
+				.join(performanceStatistic).on(performanceStatistic.performance.eq(performance))
+				.where(ticketOnSale(subSchedule, now))
+				.groupBy(performance.id, stadium.name)
+				.fetch()
+				.size()
+		);
 	}
 
 	/**

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/controller/performance/PerformanceControllerTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/controller/performance/PerformanceControllerTest.java
@@ -7,7 +7,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.math.BigDecimal;
-import java.sql.Date;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -150,8 +149,8 @@ class PerformanceControllerTest {
 				PerformanceType.CLASSIC,
 				PerformanceGenre.PLAY,
 				"대전예술의전당",
-				Date.valueOf(LocalDate.of(2025, 9, 1)),
-				Date.valueOf(LocalDate.of(2025, 9, 30)),
+				LocalDate.of(2025, 9, 1),
+				LocalDate.of(2025, 9, 30),
 				false
 			);
 

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformancePricingRepositoryTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformancePricingRepositoryTest.java
@@ -21,6 +21,7 @@ import wisoft.nextframe.schedulereservationticketing.builder.ScheduleBuilder;
 import wisoft.nextframe.schedulereservationticketing.builder.StadiumBuilder;
 import wisoft.nextframe.schedulereservationticketing.builder.StadiumSectionBuilder;
 import wisoft.nextframe.schedulereservationticketing.config.TestContainersConfig;
+import wisoft.nextframe.schedulereservationticketing.config.db.QueryDslConfig;
 import wisoft.nextframe.schedulereservationticketing.dto.performance.performancedetail.response.SeatSectionPriceResponse;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.Performance;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.PerformancePricing;
@@ -34,7 +35,7 @@ import wisoft.nextframe.schedulereservationticketing.repository.stadium.StadiumS
 
 @DataJpaTest
 @ActiveProfiles("test")
-@Import(TestContainersConfig.class)
+@Import({TestContainersConfig.class, QueryDslConfig.class})
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class PerformancePricingRepositoryTest {
 

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryTest.java
@@ -23,6 +23,7 @@ import wisoft.nextframe.schedulereservationticketing.builder.PerformanceStatisti
 import wisoft.nextframe.schedulereservationticketing.builder.ScheduleBuilder;
 import wisoft.nextframe.schedulereservationticketing.builder.StadiumBuilder;
 import wisoft.nextframe.schedulereservationticketing.config.TestContainersConfig;
+import wisoft.nextframe.schedulereservationticketing.config.db.QueryDslConfig;
 import wisoft.nextframe.schedulereservationticketing.dto.performance.performancelist.response.PerformanceSummaryResponse;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.Performance;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.Stadium;
@@ -31,7 +32,7 @@ import wisoft.nextframe.schedulereservationticketing.repository.stadium.StadiumR
 
 @DataJpaTest
 @ActiveProfiles("test")
-@Import(TestContainersConfig.class)
+@Import({TestContainersConfig.class, QueryDslConfig.class})
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class PerformanceRepositoryTest {
 

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryTest.java
@@ -214,13 +214,20 @@ class PerformanceRepositoryTest {
 					.build()
 			);
 
-			scheduleRepository.save(
-				ScheduleBuilder.builder()
-					.withPerformance(performance)
-					.withStadium(stadium)
-					.withPerformanceDatetime(startDate)
-					.build()
-			);
+			// 공연 시작일이 과거이면 티켓 판매 기간도 과거로 설정
+			final boolean isPast = startDate.isBefore(now);
+			final ScheduleBuilder scheduleBuilder = ScheduleBuilder.builder()
+				.withPerformance(performance)
+				.withStadium(stadium)
+				.withPerformanceDatetime(startDate);
+
+			if (isPast) {
+				scheduleBuilder
+					.withTicketOpenTime(startDate.minusDays(30))
+					.withTicketCloseTime(startDate.minusDays(1));
+			}
+
+			scheduleRepository.save(scheduleBuilder.build());
 		}
 	}
 

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/reservation/ReservationRepositoryTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/reservation/ReservationRepositoryTest.java
@@ -18,6 +18,7 @@ import wisoft.nextframe.schedulereservationticketing.builder.ScheduleBuilder;
 import wisoft.nextframe.schedulereservationticketing.builder.StadiumBuilder;
 import wisoft.nextframe.schedulereservationticketing.builder.UserBuilder;
 import wisoft.nextframe.schedulereservationticketing.config.TestContainersConfig;
+import wisoft.nextframe.schedulereservationticketing.config.db.QueryDslConfig;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.Performance;
 import wisoft.nextframe.schedulereservationticketing.entity.schedule.Schedule;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.Stadium;
@@ -29,7 +30,7 @@ import wisoft.nextframe.schedulereservationticketing.repository.user.UserReposit
 
 @DataJpaTest
 @ActiveProfiles("test")
-@Import(TestContainersConfig.class)
+@Import({TestContainersConfig.class, QueryDslConfig.class})
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class ReservationRepositoryTest {
 

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/review/ReviewRepositoryTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/review/ReviewRepositoryTest.java
@@ -22,6 +22,7 @@ import wisoft.nextframe.schedulereservationticketing.builder.PerformanceBuilder;
 import wisoft.nextframe.schedulereservationticketing.builder.ReviewBuilder;
 import wisoft.nextframe.schedulereservationticketing.builder.UserBuilder;
 import wisoft.nextframe.schedulereservationticketing.config.TestContainersConfig;
+import wisoft.nextframe.schedulereservationticketing.config.db.QueryDslConfig;
 import wisoft.nextframe.schedulereservationticketing.dto.review.ReviewItemResponse;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.Performance;
 import wisoft.nextframe.schedulereservationticketing.entity.review.Review;
@@ -32,7 +33,7 @@ import wisoft.nextframe.schedulereservationticketing.repository.user.UserReposit
 
 @DataJpaTest
 @ActiveProfiles("test")
-@Import(TestContainersConfig.class)
+@Import({TestContainersConfig.class, QueryDslConfig.class})
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class ReviewRepositoryTest {
 

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/seat/SeatStateRepositoryTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/seat/SeatStateRepositoryTest.java
@@ -24,6 +24,7 @@ import wisoft.nextframe.schedulereservationticketing.builder.SeatStateBuilder;
 import wisoft.nextframe.schedulereservationticketing.builder.StadiumBuilder;
 import wisoft.nextframe.schedulereservationticketing.builder.StadiumSectionBuilder;
 import wisoft.nextframe.schedulereservationticketing.config.TestContainersConfig;
+import wisoft.nextframe.schedulereservationticketing.config.db.QueryDslConfig;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.Performance;
 import wisoft.nextframe.schedulereservationticketing.entity.schedule.Schedule;
 import wisoft.nextframe.schedulereservationticketing.entity.seat.SeatState;
@@ -38,7 +39,7 @@ import wisoft.nextframe.schedulereservationticketing.repository.stadium.StadiumS
 
 @DataJpaTest
 @ActiveProfiles("test")
-@Import(TestContainersConfig.class)
+@Import({TestContainersConfig.class, QueryDslConfig.class})
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class SeatStateRepositoryTest {
 

--- a/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/stadium/SeatDefinitionRepositoryTest.java
+++ b/schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/stadium/SeatDefinitionRepositoryTest.java
@@ -23,6 +23,7 @@ import wisoft.nextframe.schedulereservationticketing.builder.SeatDefinitionBuild
 import wisoft.nextframe.schedulereservationticketing.builder.StadiumBuilder;
 import wisoft.nextframe.schedulereservationticketing.builder.StadiumSectionBuilder;
 import wisoft.nextframe.schedulereservationticketing.config.TestContainersConfig;
+import wisoft.nextframe.schedulereservationticketing.config.db.QueryDslConfig;
 import wisoft.nextframe.schedulereservationticketing.entity.performance.Performance;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.SeatDefinition;
 import wisoft.nextframe.schedulereservationticketing.entity.stadium.Stadium;
@@ -32,7 +33,7 @@ import wisoft.nextframe.schedulereservationticketing.repository.schedule.Schedul
 
 @DataJpaTest
 @ActiveProfiles("test")
-@Import(TestContainersConfig.class)
+@Import({TestContainersConfig.class, QueryDslConfig.class})
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class SeatDefinitionRepositoryTest {
 


### PR DESCRIPTION
<!-- pr-ai-generated -->

## 🛠️ 설명 (Description)

기존 {@code PerformanceRepository}에 정의되어 있던 복잡한 JPQL 쿼리들을 QueryDSL로 전환하여 가독성과 유지보수성을 개선했습니다. 특히 예매 가능한 공연 목록 조회({@code findReservablePerformances})와 조회수 기준 인기 공연 목록 조회({@code findTop10Performances}) 메소드의 쿼리가 QueryDSL로 재작성되었습니다.

## 📄 설계 문서 (Design Document)

N/A

## ✅ 테스트 계획 (Test Plan)

-   기존 {@code PerformanceRepositoryTest}의 통합 테스트를 통해 QueryDSL로 전환된 {@code findReservablePerformances} 및 {@code findTop10Performances} 메소드의 기능이 정상적으로 동작함을 확인했습니다.
-   {@code PerformanceControllerTest}에서 {@code PerformanceSummaryResponse} DTO의 날짜 타입 변경({@code java.sql.Date}에서 {@code java.time.LocalDate}로)에 맞춰 테스트 로직을 업데이트했습니다.
-   새롭게 추가된 {@code QueryDslConfig}가 여러 리포지토리 테스트 클래스(예: {@code PerformancePricingRepositoryTest}, {@code ReservationRepositoryTest}, {@code ReviewRepositoryTest}, {@code SeatStateRepositoryTest}, {@code SeatDefinitionRepositoryTest} 등)에 {@code @Import}를 통해 올바르게 적용되도록 구성했습니다.

## 📝 변경 사항 요약 (Summary)

-   **QueryDSL 의존성 추가 및 설정**:
    -   `schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/config/db/QueryDslConfig.java` 파일을 새로 생성하여 {@code JPAQueryFactory}를 스프링 빈으로 등록했습니다.
-   **PerformanceRepository 리팩토링**:
    -   `schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepository.java` 인터페이스에서 기존의 {@code findReservablePerformances} 및 {@code findTop10Performances} JPQL 쿼리를 제거하고, 새로 정의된 {@code PerformanceRepositoryCustom} 인터페이스를 상속하도록 변경했습니다.
-   **QueryDSL 기반 커스텀 리포지토리 구현**:
    -   `schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryCustom.java` 인터페이스를 새로 생성하여 {@code findReservablePerformances} 및 {@code findTop10Performances} 메소드를 정의했습니다.
    -   `schedule-reservation-ticketing/src/main/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryImpl.java` 파일을 새로 생성하여 {@code PerformanceRepositoryCustom}을 구현하고, 해당 메소드들을 QueryDSL 쿼리로 재작성했습니다.
        -   {@code findReservablePerformances} 메소드는 {@code EXISTS} 서브쿼리를 사용하여 현재 티켓 판매 기간에 해당하는 일정이 하나라도 존재하는 공연만 필터링하도록 구현했습니다.
        -   {@code findTop10Performances} 메소드는 {@code PerformanceStatistic} 엔티티와 조인하여 조회수(hit)를 기준으로 정렬하고, 예매 가능한 공연만 필터링하도록 구현했습니다.
        -   두 메소드 모두 {@code PageableExecutionUtils.getPage}를 사용하여 전체 개수(count) 쿼리의 불필요한 실행을 최적화했습니다.
        -   공연의 시작일과 종료일을 집계하기 위해 {@code schedule.performanceDatetime} 필드를 {@code Expressions.dateTemplate(java.sql.Date.class, "CAST({0} AS date)", schedule.performanceDatetime)}와 {@code MIN/MAX} 함수를 사용하여 {@code PerformanceSummaryResponse} DTO로 프로젝션하도록 구성했습니다.
        -   티켓 판매 기간 조건을 {@code ticketOnSale(QSchedule subSchedule, LocalDateTime now)} private 메소드로 분리하여 중복 코드를 제거하고 재사용성을 높였습니다.
-   **테스트 코드 업데이트**:
    -   `schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/repository/performance/PerformanceRepositoryTest.java`에서 과거 공연 생성 시 티켓 판매 기간도 과거로 설정하도록 {@code ScheduleBuilder}를 수정하여 테스트의 정확성을 높였습니다.
    -   `schedule-reservation-ticketing/src/test/java/wisoft/nextframe/schedulereservationticketing/controller/performance/PerformanceControllerTest.java`에서 {@code PerformanceSummaryResponse} 객체 생성 시 날짜 타입을 {@code java.sql.Date}에서 {@code java.time.LocalDate}로 변경했습니다.
    -   QueryDSL 설정을 사용하기 위해 다수의 {@code @DataJpaTest} 클래스에 `QueryDslConfig`를 {@code @Import} 했습니다.

## 🔗 관련 이슈 (Related Issues)

-   Closed #170

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 테스트 코드가 작성되었고, 통과했습니다.
- [x] 변경 사항에 대한 문서화가 완료되었습니다.
- [x] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

-   기존 JPQL 쿼리가 {@code EXISTS} 서브쿼리와 복잡한 {@code GROUP BY} 조건을 포함하고 있어 QueryDSL 전환을 통해 가독성과 타입 안전성을 확보했습니다.
-   {@code PerformanceRepositoryImpl}의 QueryDSL 쿼리 로직은 주석과 함께 상세히 설명되어 있습니다. 특히 {@code Projections.constructor}를 통한 DTO 생성 방식과 {@code dateTemplate}을 활용한 날짜 형식 변환에 유의해주세요.
-   {@code PageableExecutionUtils}를 활용하여 불필요한 {@code count} 쿼리 실행을 최적화했습니다.
-   {@code PerformanceSummaryResponse}의 {@code startDate} 및 {@code endDate} 필드가 이제 {@code java.time.LocalDate} 타입으로 처리됩니다.
-   티켓 판매 기간 조건을 {@code ticketOnSale} private 메소드로 분리하여 재사용성을 높였습니다.

## ➕ 추가 정보 (Additional Information)

N/A