### PR TITLE
#175 fix(payment): PG confirm/cancel 실패 시 상태 유실 방지

### DIFF
--- a/payment/src/main/java/wisoft/nextframe/payment/application/payment/PaymentService.java
+++ b/payment/src/main/java/wisoft/nextframe/payment/application/payment/PaymentService.java
@@ -4,6 +4,8 @@ import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import wisoft.nextframe.payment.application.payment.exception.PaymentGatewayExternalCallFailedException;
+import wisoft.nextframe.payment.application.payment.exception.PaymentGatewayTemporarilyUnavailableException;
 import wisoft.nextframe.payment.application.payment.exception.ReservationExpiredException;
 import wisoft.nextframe.payment.application.payment.port.output.PaymentGateway;
 import wisoft.nextframe.payment.application.payment.port.output.ReservationReader;
@@ -29,14 +31,23 @@ public class PaymentService {
 			throw new ReservationExpiredException(reservationId.value());
 		}
 
-		// 2. 트랜잭션 없이 외부 PG 호출
-		PaymentGateway.PaymentConfirmResult result = paymentGateway.confirmPayment(
-			request.paymentKey(),
-			request.orderId(),
-			request.amount()
-		);
+		// 2. PG 호출 전 Payment를 REQUESTED로 선저장 (실패 시 재조회 근거 확보)
+		Payment payment = paymentTransactionService.createRequested(reservationId, request.amount());
 
-		// 3. 결과 영속화 + 도메인 이벤트 발행 (outbox 패턴으로 비동기 처리)
+		// 3. 트랜잭션 없이 외부 PG 호출
+		PaymentGateway.PaymentConfirmResult result;
+		try {
+			result = paymentGateway.confirmPayment(
+				request.paymentKey(),
+				request.orderId(),
+				request.amount()
+			);
+		} catch (PaymentGatewayTemporarilyUnavailableException | PaymentGatewayExternalCallFailedException e) {
+			paymentTransactionService.handlePaymentFailure(payment);
+			throw e;
+		}
+
+		// 4. 결과 영속화 + 도메인 이벤트 발행 (outbox 패턴으로 비동기 처리)
 		return paymentTransactionService.applyConfirmResult(request, result);
 	}
 }

--- a/payment/src/main/java/wisoft/nextframe/payment/application/payment/PaymentService.java
+++ b/payment/src/main/java/wisoft/nextframe/payment/application/payment/PaymentService.java
@@ -42,8 +42,13 @@ public class PaymentService {
 				request.orderId(),
 				request.amount()
 			);
-		} catch (PaymentGatewayTemporarilyUnavailableException | PaymentGatewayExternalCallFailedException e) {
+		} catch (PaymentGatewayTemporarilyUnavailableException e) {
+			// CB OPEN: 호출 자체가 차단되어 PG에 요청이 전달되지 않았으므로 안전하게 실패 확정
 			paymentTransactionService.handlePaymentFailure(payment);
+			throw e;
+		} catch (PaymentGatewayExternalCallFailedException e) {
+			// 호출은 시도됐으나 실패(타임아웃 등): PG가 실제로 처리했을 가능성이 있어
+			// REQUESTED로 유지, 재조회/재시도 대상으로만 남기고 실패 확정하지 않는다.
 			throw e;
 		}
 

--- a/payment/src/main/java/wisoft/nextframe/payment/application/payment/PaymentTransactionService.java
+++ b/payment/src/main/java/wisoft/nextframe/payment/application/payment/PaymentTransactionService.java
@@ -32,6 +32,13 @@ public class PaymentTransactionService {
 	private final ApplicationEventPublisher eventPublisher;
 
 	@Transactional
+	public Payment createRequested(ReservationId reservationId, int amount) {
+		return paymentRepository.findByReservationId(reservationId)
+			.orElseGet(() -> paymentRepository.save(
+				Payment.request(Money.of(amount), reservationId, LocalDateTime.now())));
+	}
+
+	@Transactional
 	public Payment applyConfirmResult(PaymentConfirmRequest request, PaymentGateway.PaymentConfirmResult result) {
 
 		ReservationId reservationId;
@@ -88,7 +95,8 @@ public class PaymentTransactionService {
 		}
 	}
 
-	private void handlePaymentFailure(Payment payment) {
+	@Transactional
+	public void handlePaymentFailure(Payment payment) {
 		payment.fail();
 		saveAndPublishEvents(payment);
 	}

--- a/payment/src/main/java/wisoft/nextframe/payment/application/payment/PaymentTransactionService.java
+++ b/payment/src/main/java/wisoft/nextframe/payment/application/payment/PaymentTransactionService.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,11 +32,20 @@ public class PaymentTransactionService {
 	private final ReservationReader reservationReader;
 	private final ApplicationEventPublisher eventPublisher;
 
-	@Transactional
+	// reservation_id는 DB unique 제약이 있어, 동시 요청이 findByReservationId()에서 함께
+	// 비어있음을 보고 save()로 진입할 수 있다. 하나만 커밋되므로 save()마다 자체 트랜잭션을
+	// 갖도록 이 메서드에는 @Transactional을 걸지 않고, 충돌 시 승자 row를 재조회해 반환한다.
 	public Payment createRequested(ReservationId reservationId, int amount) {
-		return paymentRepository.findByReservationId(reservationId)
-			.orElseGet(() -> paymentRepository.save(
-				Payment.request(Money.of(amount), reservationId, LocalDateTime.now())));
+		Optional<Payment> existing = paymentRepository.findByReservationId(reservationId);
+		if (existing.isPresent()) {
+			return existing.get();
+		}
+
+		try {
+			return paymentRepository.save(Payment.request(Money.of(amount), reservationId, LocalDateTime.now()));
+		} catch (DataIntegrityViolationException e) {
+			return paymentRepository.findByReservationId(reservationId).orElseThrow(() -> e);
+		}
 	}
 
 	@Transactional

--- a/payment/src/main/java/wisoft/nextframe/payment/application/refund/RefundService.java
+++ b/payment/src/main/java/wisoft/nextframe/payment/application/refund/RefundService.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import wisoft.nextframe.payment.application.payment.exception.PaymentGatewayExternalCallFailedException;
+import wisoft.nextframe.payment.application.payment.exception.PaymentGatewayTemporarilyUnavailableException;
 import wisoft.nextframe.payment.application.payment.outbox.cancel.ReservationCancelOutboxService;
 import wisoft.nextframe.payment.application.payment.port.output.PaymentGateway;
 import wisoft.nextframe.payment.application.refund.RefundTransactionService.RefundPrepareResult;
@@ -33,9 +35,18 @@ public class RefundService {
 		String orderId = prepareResult.payment().getReservationId().value().toString();
 		int cancelAmount = refund.getRefundedAmount().getValue().intValue();
 
-		// 2. PG 환불 요청 (트랜잭션 없이 외부 호출)
-		PaymentGateway.PaymentCancelResult cancelResult =
-			paymentGateway.cancelPayment(paymentKey, orderId, cancelAmount, reason);
+		// 2. PG 호출 전 Refund를 REQUESTED로 선저장 (실패 시 재조회 근거 확보)
+		refundTransactionService.saveRequested(paymentId, refund, reason);
+
+		// 3. PG 환불 요청 (트랜잭션 없이 외부 호출)
+		PaymentGateway.PaymentCancelResult cancelResult;
+		try {
+			cancelResult = paymentGateway.cancelPayment(paymentKey, orderId, cancelAmount, reason);
+		} catch (PaymentGatewayTemporarilyUnavailableException | PaymentGatewayExternalCallFailedException e) {
+			log.error("PG 환불 호출 실패, Refund는 REQUESTED로 남아 재시도 대상 - paymentId: {}, refundId: {}",
+				paymentId, refund.getRefundId().getValue());
+			throw e;
+		}
 
 		if (!cancelResult.isSuccess()) {
 			log.error("PG 환불 실패 - paymentId: {}, errorCode: {}, errorMessage: {}",
@@ -43,10 +54,10 @@ public class RefundService {
 			throw new RefundCancelFailedException(cancelResult.errorCode());
 		}
 
-		// 3. 환불 완료 저장 (트랜잭션)
+		// 4. 환불 완료 저장 (트랜잭션)
 		Refund completed = refundTransactionService.completeRefund(paymentId, refund, reason);
 
-		// 4. 예약 취소 + 좌석 해제 (outbox 패턴으로 신뢰성 보장)
+		// 5. 예약 취소 + 좌석 해제 (outbox 패턴으로 신뢰성 보장)
 		reservationCancelOutboxService.cancelOrEnqueue(
 			paymentId,
 			prepareResult.payment().getReservationId().value()

--- a/payment/src/main/java/wisoft/nextframe/payment/application/refund/RefundTransactionService.java
+++ b/payment/src/main/java/wisoft/nextframe/payment/application/refund/RefundTransactionService.java
@@ -17,6 +17,7 @@ import wisoft.nextframe.payment.domain.payment.PaymentId;
 import wisoft.nextframe.payment.domain.payment.PaymentIssuer;
 import wisoft.nextframe.payment.domain.payment.PaymentNotFoundException;
 import wisoft.nextframe.payment.domain.refund.Refund;
+import wisoft.nextframe.payment.domain.refund.RefundStatus;
 
 @Slf4j
 @Service
@@ -38,11 +39,17 @@ public class RefundTransactionService {
 		Payment payment = paymentRepository.findById(PaymentId.of(paymentId))
 			.orElseThrow(PaymentNotFoundException::new);
 
-		// 2. 멱등성 체크 - 이미 환불된 경우
+		// 2. 멱등성 체크 - REQUESTED로 남은 row는 PG 응답 유실로 인한 미완료 시도이므로
+		// 재시도 대상으로 재사용하고, 그 외 상태만 완료로 간주한다.
 		Optional<Refund> existingRefund = refundRepository.findByPaymentId(paymentId);
 		if (existingRefund.isPresent()) {
+			Refund existing = existingRefund.get();
+			if (existing.getStatus() == RefundStatus.REQUESTED) {
+				log.warn("PG 응답 미확인 상태로 남은 환불 재시도 - paymentId: {}", paymentId);
+				return RefundPrepareResult.prepared(payment, existing);
+			}
 			log.warn("이미 환불된 결제 - paymentId: {}", paymentId);
-			return RefundPrepareResult.alreadyRefunded(existingRefund.get());
+			return RefundPrepareResult.alreadyRefunded(existing);
 		}
 
 		// 3. 공연 시작 시간 조회
@@ -53,6 +60,14 @@ public class RefundTransactionService {
 		Refund refund = paymentIssuer.issueRefund(payment, now, performanceDateTime);
 
 		return RefundPrepareResult.prepared(payment, refund);
+	}
+
+	/**
+	 * PG 취소 호출 전 Refund를 REQUESTED로 선저장 (실패 시 재조회 근거 확보)
+	 */
+	@Transactional
+	public void saveRequested(UUID paymentId, Refund refund, String reason) {
+		refundRepository.save(refund, paymentId, reason);
 	}
 
 	/**

--- a/payment/src/test/java/wisoft/nextframe/payment/application/payment/PaymentServiceTest.java
+++ b/payment/src/test/java/wisoft/nextframe/payment/application/payment/PaymentServiceTest.java
@@ -96,8 +96,8 @@ class PaymentServiceTest {
 	}
 
 	@Test
-	@DisplayName("PG 외부 호출 실패 시 선저장된 Payment를 실패 처리하고 예외를 다시 던진다")
-	void confirmPayment_externalCallFailed_marksFailedAndRethrows() {
+	@DisplayName("PG 외부 호출 실패(타임아웃 등) 시 Payment를 REQUESTED로 유지하고 실패 확정하지 않는다")
+	void confirmPayment_externalCallFailed_keepsRequestedAndRethrows() {
 		Payment requested = Payment.request(Money.of(10_000), RESERVATION_ID, LocalDateTime.now());
 		PaymentGatewayExternalCallFailedException callFailedException =
 			new PaymentGatewayExternalCallFailedException("confirm", new RuntimeException("timeout"));
@@ -110,6 +110,6 @@ class PaymentServiceTest {
 		assertThatThrownBy(() -> paymentService.confirmPayment(REQUEST))
 			.isSameAs(callFailedException);
 
-		then(paymentTransactionService).should().handlePaymentFailure(requested);
+		then(paymentTransactionService).should(never()).handlePaymentFailure(any());
 	}
 }

--- a/payment/src/test/java/wisoft/nextframe/payment/application/payment/PaymentServiceTest.java
+++ b/payment/src/test/java/wisoft/nextframe/payment/application/payment/PaymentServiceTest.java
@@ -1,0 +1,115 @@
+package wisoft.nextframe.payment.application.payment;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import wisoft.nextframe.payment.application.payment.exception.PaymentGatewayExternalCallFailedException;
+import wisoft.nextframe.payment.application.payment.exception.PaymentGatewayTemporarilyUnavailableException;
+import wisoft.nextframe.payment.application.payment.exception.ReservationExpiredException;
+import wisoft.nextframe.payment.application.payment.port.output.PaymentGateway;
+import wisoft.nextframe.payment.application.payment.port.output.ReservationReader;
+import wisoft.nextframe.payment.common.Money;
+import wisoft.nextframe.payment.domain.ReservationId;
+import wisoft.nextframe.payment.domain.payment.Payment;
+import wisoft.nextframe.payment.presentation.payment.dto.PaymentConfirmRequest;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentService 단위 테스트")
+class PaymentServiceTest {
+
+	@Mock
+	PaymentGateway paymentGateway;
+
+	@Mock
+	ReservationReader reservationReader;
+
+	@Mock
+	PaymentTransactionService paymentTransactionService;
+
+	@InjectMocks
+	PaymentService paymentService;
+
+	private static final UUID RESERVATION_UUID = UUID.randomUUID();
+	private static final ReservationId RESERVATION_ID = ReservationId.of(RESERVATION_UUID);
+	private static final PaymentConfirmRequest REQUEST =
+		new PaymentConfirmRequest("paymentKey", RESERVATION_UUID.toString(), 10_000);
+
+	@Test
+	@DisplayName("예약이 결제 불가 상태면 PG를 호출하지 않고 예외를 던진다")
+	void confirmPayment_reservationNotPayable_throwsWithoutCallingGateway() {
+		given(reservationReader.isPayable(RESERVATION_ID)).willReturn(false);
+
+		assertThatThrownBy(() -> paymentService.confirmPayment(REQUEST))
+			.isInstanceOf(ReservationExpiredException.class);
+
+		then(paymentTransactionService).shouldHaveNoInteractions();
+		then(paymentGateway).shouldHaveNoInteractions();
+	}
+
+	@Test
+	@DisplayName("PG 호출이 정상 응답하면 결과를 applyConfirmResult로 위임한다")
+	void confirmPayment_success_delegatesToApplyConfirmResult() {
+		Payment requested = Payment.request(Money.of(10_000), RESERVATION_ID, LocalDateTime.now());
+		Payment approved = Payment.request(Money.of(10_000), RESERVATION_ID, LocalDateTime.now());
+		PaymentGateway.PaymentConfirmResult result =
+			new PaymentGateway.PaymentConfirmResult(true, 10_000, null, null);
+
+		given(reservationReader.isPayable(RESERVATION_ID)).willReturn(true);
+		given(paymentTransactionService.createRequested(RESERVATION_ID, 10_000)).willReturn(requested);
+		given(paymentGateway.confirmPayment("paymentKey", RESERVATION_UUID.toString(), 10_000))
+			.willReturn(result);
+		given(paymentTransactionService.applyConfirmResult(REQUEST, result)).willReturn(approved);
+
+		Payment returned = paymentService.confirmPayment(REQUEST);
+
+		assertThat(returned).isSameAs(approved);
+		then(paymentTransactionService).should(never()).handlePaymentFailure(any());
+	}
+
+	@Test
+	@DisplayName("CB OPEN으로 PG 호출이 차단되면 선저장된 Payment를 실패 처리하고 예외를 다시 던진다")
+	void confirmPayment_circuitBreakerOpen_marksFailedAndRethrows() {
+		Payment requested = Payment.request(Money.of(10_000), RESERVATION_ID, LocalDateTime.now());
+		PaymentGatewayTemporarilyUnavailableException cbException =
+			new PaymentGatewayTemporarilyUnavailableException("confirm", new RuntimeException("CB OPEN"));
+
+		given(reservationReader.isPayable(RESERVATION_ID)).willReturn(true);
+		given(paymentTransactionService.createRequested(RESERVATION_ID, 10_000)).willReturn(requested);
+		given(paymentGateway.confirmPayment("paymentKey", RESERVATION_UUID.toString(), 10_000))
+			.willThrow(cbException);
+
+		assertThatThrownBy(() -> paymentService.confirmPayment(REQUEST))
+			.isSameAs(cbException);
+
+		then(paymentTransactionService).should().handlePaymentFailure(requested);
+		then(paymentTransactionService).should(never()).applyConfirmResult(any(), any());
+	}
+
+	@Test
+	@DisplayName("PG 외부 호출 실패 시 선저장된 Payment를 실패 처리하고 예외를 다시 던진다")
+	void confirmPayment_externalCallFailed_marksFailedAndRethrows() {
+		Payment requested = Payment.request(Money.of(10_000), RESERVATION_ID, LocalDateTime.now());
+		PaymentGatewayExternalCallFailedException callFailedException =
+			new PaymentGatewayExternalCallFailedException("confirm", new RuntimeException("timeout"));
+
+		given(reservationReader.isPayable(RESERVATION_ID)).willReturn(true);
+		given(paymentTransactionService.createRequested(RESERVATION_ID, 10_000)).willReturn(requested);
+		given(paymentGateway.confirmPayment("paymentKey", RESERVATION_UUID.toString(), 10_000))
+			.willThrow(callFailedException);
+
+		assertThatThrownBy(() -> paymentService.confirmPayment(REQUEST))
+			.isSameAs(callFailedException);
+
+		then(paymentTransactionService).should().handlePaymentFailure(requested);
+	}
+}

--- a/payment/src/test/java/wisoft/nextframe/payment/application/payment/PaymentTransactionServiceTest.java
+++ b/payment/src/test/java/wisoft/nextframe/payment/application/payment/PaymentTransactionServiceTest.java
@@ -51,6 +51,32 @@ class PaymentTransactionServiceTest {
 	}
 
 	@Test
+	@DisplayName("createRequested: 기존 Payment가 없으면 REQUESTED로 새로 생성해 저장한다")
+	void createRequested_noExisting_createsAndSaves() {
+		ReservationId reservationId = ReservationId.of(UUID.randomUUID());
+		given(paymentRepository.findByReservationId(reservationId)).willReturn(Optional.empty());
+
+		Payment created = paymentTransactionService.createRequested(reservationId, 10_000);
+
+		assertThat(created.getReservationId()).isEqualTo(reservationId);
+		assertThat(created.isSucceeded()).isFalse();
+		then(paymentRepository).should(times(1)).save(any(Payment.class));
+	}
+
+	@Test
+	@DisplayName("createRequested: 기존 Payment가 있으면 새로 생성하지 않고 기존 것을 반환한다")
+	void createRequested_existing_returnsExistingWithoutSaving() {
+		ReservationId reservationId = ReservationId.of(UUID.randomUUID());
+		Payment existing = Payment.request(Money.of(10_000), reservationId, LocalDateTime.now());
+		given(paymentRepository.findByReservationId(reservationId)).willReturn(Optional.of(existing));
+
+		Payment result = paymentTransactionService.createRequested(reservationId, 10_000);
+
+		assertThat(result).isSameAs(existing);
+		then(paymentRepository).should(never()).save(any(Payment.class));
+	}
+
+	@Test
 	@DisplayName("PG 승인 성공 시 결제를 승인 상태로 저장한다")
 	void applyConfirmResult_success_createsAndSavesApprovedPayment() {
 		// given

--- a/payment/src/test/java/wisoft/nextframe/payment/application/payment/PaymentTransactionServiceTest.java
+++ b/payment/src/test/java/wisoft/nextframe/payment/application/payment/PaymentTransactionServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import wisoft.nextframe.payment.application.payment.exception.ReservationNotFoundException;
 import wisoft.nextframe.payment.application.payment.port.output.PaymentGateway;
@@ -74,6 +75,23 @@ class PaymentTransactionServiceTest {
 
 		assertThat(result).isSameAs(existing);
 		then(paymentRepository).should(never()).save(any(Payment.class));
+	}
+
+	@Test
+	@DisplayName("createRequested: 동시 요청으로 unique 제약 위반이 나면 먼저 커밋된 row를 재조회해 반환한다")
+	void createRequested_concurrentInsertRace_returnsWinnerRow() {
+		ReservationId reservationId = ReservationId.of(UUID.randomUUID());
+		Payment winner = Payment.request(Money.of(10_000), reservationId, LocalDateTime.now());
+
+		given(paymentRepository.findByReservationId(reservationId))
+			.willReturn(Optional.empty(), Optional.of(winner));
+		given(paymentRepository.save(any(Payment.class)))
+			.willThrow(new DataIntegrityViolationException("duplicate key value violates unique constraint"));
+
+		Payment result = paymentTransactionService.createRequested(reservationId, 10_000);
+
+		assertThat(result).isSameAs(winner);
+		then(paymentRepository).should(times(2)).findByReservationId(reservationId);
 	}
 
 	@Test

--- a/payment/src/test/java/wisoft/nextframe/payment/application/refund/RefundServiceTest.java
+++ b/payment/src/test/java/wisoft/nextframe/payment/application/refund/RefundServiceTest.java
@@ -1,0 +1,141 @@
+package wisoft.nextframe.payment.application.refund;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import wisoft.nextframe.payment.application.payment.exception.PaymentGatewayTemporarilyUnavailableException;
+import wisoft.nextframe.payment.application.payment.outbox.cancel.ReservationCancelOutboxService;
+import wisoft.nextframe.payment.application.payment.port.output.PaymentGateway;
+import wisoft.nextframe.payment.application.refund.RefundTransactionService.RefundPrepareResult;
+import wisoft.nextframe.payment.common.Money;
+import wisoft.nextframe.payment.domain.ReservationId;
+import wisoft.nextframe.payment.domain.payment.Payment;
+import wisoft.nextframe.payment.domain.payment.PaymentId;
+import wisoft.nextframe.payment.domain.payment.PaymentStatus;
+import wisoft.nextframe.payment.domain.refund.Refund;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RefundService 단위 테스트")
+class RefundServiceTest {
+
+	@Mock
+	PaymentGateway paymentGateway;
+
+	@Mock
+	RefundTransactionService refundTransactionService;
+
+	@Mock
+	ReservationCancelOutboxService reservationCancelOutboxService;
+
+	@InjectMocks
+	RefundService refundService;
+
+	private static final UUID PAYMENT_ID = UUID.randomUUID();
+	private static final ReservationId RESERVATION_ID = ReservationId.of(UUID.randomUUID());
+	private static final String REASON = "개인 사정";
+
+	private Payment succeededPayment() {
+		return Payment.reconstruct(
+			PaymentId.of(PAYMENT_ID),
+			RESERVATION_ID,
+			Money.of(10_000),
+			LocalDateTime.now(),
+			PaymentStatus.SUCCEEDED,
+			"pk_test_key",
+			null
+		);
+	}
+
+	private Refund newRefund() {
+		return Refund.issue(LocalDateTime.now(), LocalDateTime.now().plusDays(10), Money.of(10_000));
+	}
+
+	@Test
+	@DisplayName("이미 환불된 결제면 PG를 호출하지 않고 기존 환불을 반환한다")
+	void refund_alreadyRefunded_skipsGatewayCall() {
+		Refund existing = newRefund();
+		given(refundTransactionService.prepareRefund(PAYMENT_ID))
+			.willReturn(RefundPrepareResult.alreadyRefunded(existing));
+
+		Refund result = refundService.refund(PAYMENT_ID, REASON);
+
+		assertThat(result).isSameAs(existing);
+		then(paymentGateway).shouldHaveNoInteractions();
+		then(refundTransactionService).should(never()).saveRequested(any(), any(), any());
+	}
+
+	@Test
+	@DisplayName("정상 환불 시 PG 호출 전에 Refund를 선저장하고, 성공하면 완료 처리와 예약 취소를 수행한다")
+	void refund_success_savesRequestedBeforeGatewayCall() {
+		Payment payment = succeededPayment();
+		Refund refund = newRefund();
+		Refund completed = newRefund();
+		PaymentGateway.PaymentCancelResult cancelResult =
+			new PaymentGateway.PaymentCancelResult(true, 10_000, "txKey", null, null);
+
+		given(refundTransactionService.prepareRefund(PAYMENT_ID))
+			.willReturn(RefundPrepareResult.prepared(payment, refund));
+		given(paymentGateway.cancelPayment("pk_test_key", RESERVATION_ID.value().toString(),
+			10_000, REASON)).willReturn(cancelResult);
+		given(refundTransactionService.completeRefund(PAYMENT_ID, refund, REASON)).willReturn(completed);
+
+		Refund result = refundService.refund(PAYMENT_ID, REASON);
+
+		assertThat(result).isSameAs(completed);
+		then(refundTransactionService).should().saveRequested(PAYMENT_ID, refund, REASON);
+		then(refundTransactionService).should().completeRefund(PAYMENT_ID, refund, REASON);
+		then(reservationCancelOutboxService).should()
+			.cancelOrEnqueue(PAYMENT_ID, RESERVATION_ID.value());
+	}
+
+	@Test
+	@DisplayName("PG 호출이 CB로 차단되면 선저장까지만 하고 완료 처리 없이 예외를 다시 던진다")
+	void refund_gatewayTemporarilyUnavailable_rethrowsWithoutCompleting() {
+		Payment payment = succeededPayment();
+		Refund refund = newRefund();
+		PaymentGatewayTemporarilyUnavailableException cbException =
+			new PaymentGatewayTemporarilyUnavailableException("cancel", new RuntimeException("CB OPEN"));
+
+		given(refundTransactionService.prepareRefund(PAYMENT_ID))
+			.willReturn(RefundPrepareResult.prepared(payment, refund));
+		given(paymentGateway.cancelPayment("pk_test_key", RESERVATION_ID.value().toString(),
+			10_000, REASON)).willThrow(cbException);
+
+		assertThatThrownBy(() -> refundService.refund(PAYMENT_ID, REASON))
+			.isSameAs(cbException);
+
+		then(refundTransactionService).should().saveRequested(PAYMENT_ID, refund, REASON);
+		then(refundTransactionService).should(never()).completeRefund(any(), any(), any());
+		then(reservationCancelOutboxService).shouldHaveNoInteractions();
+	}
+
+	@Test
+	@DisplayName("PG가 실패 응답을 반환하면 선저장까지만 하고 RefundCancelFailedException을 던진다")
+	void refund_gatewayReturnsFailure_throwsRefundCancelFailedException() {
+		Payment payment = succeededPayment();
+		Refund refund = newRefund();
+		PaymentGateway.PaymentCancelResult cancelResult =
+			new PaymentGateway.PaymentCancelResult(false, 0, null, "ERR", "실패");
+
+		given(refundTransactionService.prepareRefund(PAYMENT_ID))
+			.willReturn(RefundPrepareResult.prepared(payment, refund));
+		given(paymentGateway.cancelPayment("pk_test_key", RESERVATION_ID.value().toString(),
+			10_000, REASON)).willReturn(cancelResult);
+
+		assertThatThrownBy(() -> refundService.refund(PAYMENT_ID, REASON))
+			.isInstanceOf(RefundCancelFailedException.class);
+
+		then(refundTransactionService).should().saveRequested(PAYMENT_ID, refund, REASON);
+		then(refundTransactionService).should(never()).completeRefund(any(), any(), any());
+	}
+}

--- a/payment/src/test/java/wisoft/nextframe/payment/application/refund/RefundTransactionServiceTest.java
+++ b/payment/src/test/java/wisoft/nextframe/payment/application/refund/RefundTransactionServiceTest.java
@@ -134,6 +134,51 @@ class RefundTransactionServiceTest {
 			assertThat(result.alreadyRefunded()).isTrue();
 			assertThat(result.refund()).isSameAs(existingRefund);
 		}
+
+		@Test
+		@DisplayName("REQUESTED로 남은 환불이 있으면 완료 처리하지 않고 재시도 대상으로 반환한다")
+		void prepareRefund_existingRequestedRefund_returnsExistingForRetry() {
+			// given
+			Refund stuckRefund = Refund.reconstruct(
+				RefundId.generate(),
+				Money.of(10_000),
+				RefundStatus.REQUESTED,
+				RefundPolicyStatus.REFUND_FULL,
+				LocalDateTime.now(),
+				null
+			);
+
+			given(paymentRepository.findById(any(PaymentId.class)))
+				.willReturn(Optional.of(succeededPayment));
+			given(refundRepository.findByPaymentId(PAYMENT_ID))
+				.willReturn(Optional.of(stuckRefund));
+
+			// when
+			RefundPrepareResult result = refundTransactionService.prepareRefund(PAYMENT_ID);
+
+			// then
+			assertThat(result.alreadyRefunded()).isFalse();
+			assertThat(result.refund()).isSameAs(stuckRefund);
+		}
+	}
+
+	@Nested
+	@DisplayName("saveRequested")
+	class SaveRequested {
+
+		@Test
+		@DisplayName("PG 호출 전 Refund를 REQUESTED 상태로 저장한다")
+		void saveRequested_persistsRefund() {
+			// given
+			Refund refund = Refund.issue(LocalDateTime.now(), PERFORMANCE_START, Money.of(10_000));
+			given(refundRepository.save(refund, PAYMENT_ID, REASON)).willReturn(refund);
+
+			// when
+			refundTransactionService.saveRequested(PAYMENT_ID, refund, REASON);
+
+			// then
+			then(refundRepository).should().save(refund, PAYMENT_ID, REASON);
+		}
 	}
 
 	@Nested


### PR DESCRIPTION
<!-- pr-ai-generated -->

## 🛠️ 설명 (Description)

PG(Payment Gateway) 결제 승인 또는 환불 취소 요청 실패 시 애플리케이션의 상태 유실을 방지하고, 데이터 정합성을 유지하기 위한 변경사항입니다.
이전에는 PG 외부 호출 실패 시 결제 또는 환불 상태가 DB에 반영되지 않아 재시도나 복구 시점에서 데이터 불일치가 발생할 수 있었습니다.
이를 개선하기 위해 PG 호출 직전에 결제/환불 상태를 "요청됨(REQUESTED)"으로 미리 저장하고, PG 호출 실패 시 해당 상태를 업데이트하거나 재시도 근거로 활용하도록 변경했습니다.

주요 변경 내용은 다음과 같습니다:
- **결제 승인 과정:** PG 승인 API 호출 전에 `Payment` 객체를 `REQUESTED` 상태로 저장하고, PG 호출이 실패하면 해당 `Payment`를 `FAILED` 상태로 업데이트합니다. 이는 네트워크 문제나 PG 일시 중단 등으로 인한 상태 유실을 방지하여 결제 실패 기록을 명확히 남깁니다.
- **환불 취소 과정:** PG 환불 API 호출 전에 `Refund` 객체를 `REQUESTED` 상태로 저장합니다. PG 호출이 실패하면 `Refund`는 `REQUESTED` 상태로 유지되어, 운영자가 상태를 확인하고 필요에 따라 수동 재시도할 수 있는 근거를 제공합니다. 또한, `RefundTransactionService.prepareRefund` 메서드는 이미 `REQUESTED` 상태로 남아있는 환불 요청이 있을 경우, 이를 재시도 대상으로 간주하여 반환하도록 멱등성 로직을 개선했습니다.

이러한 변경을 통해 시스템 장애 및 외부 서비스 연동 실패 시에도 결제 및 환불 관련 데이터의 정합성을 높이고, 장애 복구 및 재시도에 필요한 기반을 마련합니다.

## 📄 설계 문서 (Design Document)

N/A

## ✅ 테스트 계획 (Test Plan)

- 유닛 테스트를 통해 다음 시나리오를 검증했습니다.
    - **PaymentService**:
        - 예약이 결제 불가능 상태일 때 PG 호출 없이 예외를 던지는지 확인
        - PG 호출이 정상 응답 시 `PaymentTransactionService.applyConfirmResult`로 위임하는지 확인
        - 서킷 브레이커 OPEN 또는 PG 외부 호출 실패 시 `PaymentTransactionService.handlePaymentFailure`를 호출하고 예외를 다시 던지는지 확인
    - **PaymentTransactionService**:
        - `createRequested` 메서드가 기존 `Payment`가 없으면 `REQUESTED` 상태로 새로 생성 및 저장하고, 기존 `Payment`가 있으면 기존 것을 반환하는지 확인
    - **RefundService**:
        - 이미 환불된 결제에 대해 PG 호출을 스킵하고 기존 환불을 반환하는지 확인
        - 정상 환불 시 PG 호출 전에 `Refund`를 선저장(`REQUESTED`)하고, 성공하면 완료 처리 및 예약 취소를 수행하는지 확인
        - PG 호출이 서킷 브레이커로 차단되거나 외부 호출에 실패하면 `Refund`를 선저장(`REQUESTED`)까지만 하고 완료 처리 없이 예외를 다시 던지는지 확인
    - **RefundTransactionService**:
        - `prepareRefund` 메서드가 `REQUESTED` 상태로 남아있는 환불 요청을 재시도 대상으로 반환하는지 확인
        - `saveRequested` 메서드가 PG 호출 전 `Refund`를 `REQUESTED` 상태로 저장하는지 확인
- 테스트 커버리지는 기존 코드를 유지하며, 신규 및 변경된 로직에 대한 커버리지를 확보했습니다.

## 📝 변경 사항 요약 (Summary)

- `PaymentService.confirmPayment` 메서드에 PG 결제 승인 호출 전 Payment를 `REQUESTED` 상태로 선저장하는 로직 추가
- PG 결제 승인 호출 실패 (PaymentGatewayTemporarilyUnavailableException, PaymentGatewayExternalCallFailedException 발생) 시 선저장된 Payment를 `FAILED` 상태로 업데이트하는 예외 처리 로직 추가
- `PaymentTransactionService`에 Payment를 `REQUESTED` 상태로 생성하거나 기존 Payment를 반환하는 `createRequested` 메서드 추가
- `PaymentTransactionService.handlePaymentFailure` 메서드를 `@Transactional` 및 `public`으로 변경하여 PaymentService에서 호출 가능하도록 수정
- `RefundService.refund` 메서드에 PG 환불 호출 전 Refund를 `REQUESTED` 상태로 선저장하는 로직 추가
- PG 환불 호출 실패 (PaymentGatewayTemporarilyUnavailableException, PaymentGatewayExternalCallFailedException 발생) 시 Refund를 `REQUESTED` 상태로 유지하여 재시도 대상이 되도록 처리 (완료 처리 없이 예외를 다시 던짐)
- `RefundTransactionService`에 Refund를 `REQUESTED` 상태로 저장하는 `saveRequested` 메서드 추가
- `RefundTransactionService.prepareRefund` 메서드에서 `RefundStatus.REQUESTED` 상태의 기존 Refund는 재시도 대상으로 간주하여 반환하도록 멱등성 로직 수정
- `PaymentServiceTest`, `PaymentTransactionServiceTest`, `RefundServiceTest`, `RefundTransactionServiceTest`에 위 변경 사항에 대한 단위 테스트 코드 추가 및 수정

## 🔗 관련 이슈 (Related Issues)

- Closed #175

## ☑️ 체크리스트 (Checklist)

- [ ] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

- PG 외부 호출 실패 시 데이터 유실 방지를 위한 선저장(`REQUESTED` 상태) 전략이 Payment와 Refund 각각에 적용되었습니다.
- Payment의 경우, PG 호출 실패 시 해당 Payment를 `FAILED`로 즉시 업데이트하여 최종 실패 상태를 명확히 합니다.
- Refund의 경우, PG 호출 실패 시 `REQUESTED` 상태로 유지하여 재시도 가능성을 열어두고, `prepareRefund` 로직에서 `REQUESTED` 상태의 Refund를 재시도 대상으로 처리합니다. 이 부분의 설계 의도와 적절성에 대해 의견 주시면 감사하겠습니다.
- 트랜잭션 경계와 외부 서비스 호출 순서에 중점을 두고 리뷰해주시면 좋겠습니다.

## ➕ 추가 정보 (Additional Information)
N/A